### PR TITLE
 Adding in unit tests, and Stop / Start switch

### DIFF
--- a/RacingAidTests/RacingAidTests.csproj
+++ b/RacingAidTests/RacingAidTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0-windows7.0</TargetFramework>        
+        <TargetFramework>net8.0-windows</TargetFramework>        
         <LangVersion>latest</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>

--- a/RacingAidTests/RacingAidTests.csproj
+++ b/RacingAidTests/RacingAidTests.csproj
@@ -1,12 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net8.0-windows7.0</TargetFramework>        
         <LangVersion>latest</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\RacingAidWpf\RacingAidWpf.csproj" />
+    </ItemGroup>
 
     <ItemGroup>
         <PackageReference Include="coverlet.collector" Version="6.0.2"/>
@@ -15,6 +19,9 @@
         <PackageReference Include="NUnit" Version="4.2.2"/>
         <PackageReference Include="NUnit.Analyzers" Version="4.3.0"/>
         <PackageReference Include="NUnit3TestAdapter" Version="4.6.0"/>
+
+        <!-- Moq for Mocking -->
+        <PackageReference Include="Moq" Version="4.18.4" />
     </ItemGroup>
 
     <ItemGroup>

--- a/RacingAidTests/RacingWidWpf/ViewModel/MainWindowViewModelTests.cs
+++ b/RacingAidTests/RacingWidWpf/ViewModel/MainWindowViewModelTests.cs
@@ -1,0 +1,91 @@
+using NUnit.Framework;
+using Moq;
+using RacingAidWpf.OverlayManagement;
+using RacingAidWpf.ViewModel;
+using RacingAidWpf.View;
+
+
+namespace RacingAidWpf.Tests.ViewModel
+{
+    [Apartment(ApartmentState.STA)]
+    [TestFixture]
+    public class MainWindowViewModelTests
+    {
+        private Mock<OverlayController> _overlayControllerMock;
+        private MainWindowViewModel _viewModel;
+
+        [SetUp]
+        public void Setup()
+        {
+
+
+            // Mock the OverlayController
+            _overlayControllerMock = new Mock<OverlayController>();
+
+            var telemetryOverlayMock = new Mock<TelemetryOverlay>();
+            _overlayControllerMock
+                .Setup(c => c.AddOverlay(It.IsAny<TelemetryOverlay>()))
+                .Verifiable();
+            
+            // Configure mock behavior for IsRepositioningEnabled
+            _overlayControllerMock.SetupProperty(o => o.IsRepositioningEnabled, false);
+
+            // Create the ViewModel instance, injecting the mocked OverlayController
+            _viewModel = new MainWindowViewModel(_overlayControllerMock.Object);
+        }
+
+        [Test]
+        public void ToggleOverlayRepositioning_TogglesIsRepositionEnabled()
+        {
+            // Arrange
+            _viewModel.Start(); // Ensure IsStarted is true
+
+            // Act
+            _viewModel.ToggleOverlayRepositioning();
+
+            // Assert
+            Assert.That(_viewModel.IsRepositionEnabled, Is.True, "IsRepositionEnabled should be true after toggling.");
+
+            // Act again to toggle back
+            _viewModel.ToggleOverlayRepositioning();
+
+            // Assert
+            Assert.That(_viewModel.IsRepositionEnabled, Is.False, "IsRepositionEnabled should be false after toggling again.");
+        }
+
+        [Test]
+        public void ToggleOverlayRepositioning_DoesNothingIfNotStarted()
+        {
+            // Arrange
+            _viewModel.Stop(); // Ensure IsStarted is false
+
+            // Act
+            _viewModel.ToggleOverlayRepositioning();
+
+            // Assert
+            Assert.That(_viewModel.IsRepositionEnabled, Is.False, "IsRepositionEnabled should remain false if IsStarted is false.");
+            Assert.That(_overlayControllerMock.Object.IsRepositioningEnabled, Is.False, "OverlayController.IsRepositioningEnabled should remain false.");
+        }
+
+        [Test]
+        public void IsRepositionEnabled_RaisesPropertyChanged()
+        {
+            // Arrange
+            bool propertyChangedTriggered = false;
+            _viewModel.PropertyChanged += (sender, args) =>
+            {
+                if (args.PropertyName == nameof(_viewModel.IsRepositionEnabled))
+                {
+                    propertyChangedTriggered = true;
+                }
+            };
+
+            // Act
+            _viewModel.Start();
+            _viewModel.ToggleOverlayRepositioning();
+
+            // Assert
+            Assert.That(propertyChangedTriggered, Is.True, "PropertyChanged should be triggered for IsRepositionEnabled.");
+        }
+    }
+}

--- a/RacingAidTests/RacingWidWpf/ViewModel/MainWindowViewModelTests.cs
+++ b/RacingAidTests/RacingWidWpf/ViewModel/MainWindowViewModelTests.cs
@@ -17,8 +17,6 @@ namespace RacingAidWpf.Tests.ViewModel
         [SetUp]
         public void Setup()
         {
-
-
             // Mock the OverlayController
             _overlayControllerMock = new Mock<OverlayController>();
 

--- a/RacingAidWpf/Configuration/Config.cs
+++ b/RacingAidWpf/Configuration/Config.cs
@@ -12,16 +12,16 @@ public class Config : IConfig
     {
         if (!File.Exists(configFilePath))
             File.Create(configFilePath);
-        
+
         configParser = new ConfigParser(configFilePath);
     }
 
     public bool TryGetBool(string section, string key, out bool? value)
     {
         value = null;
-        if (configParser.GetValue(section, key, true) is {} configValue)
+        if (configParser.GetValue(section, key, true) is { } configValue)
             value = configValue;
-        
+
         return value != null;
     }
 
@@ -30,7 +30,7 @@ public class Config : IConfig
         value = null;
         if (configParser.GetValue(section, key, 0) is { } configValue)
             value = configValue;
-        
+
         return value.HasValue;
     }
 

--- a/RacingAidWpf/OverlayManagement/OverlayController.cs
+++ b/RacingAidWpf/OverlayManagement/OverlayController.cs
@@ -14,7 +14,7 @@ public class OverlayController
     private readonly List<Overlay> overlays = [];
     private bool isRepositionEnabled;
 
-    public bool IsRepositioningEnabled
+    public virtual bool IsRepositioningEnabled
     {
         get => isRepositionEnabled;
         set
@@ -31,7 +31,7 @@ public class OverlayController
         }
     }
 
-    public void AddOverlay(Overlay overlay)
+    public virtual void AddOverlay(Overlay overlay)
     {
         overlays.Add(overlay);
     }

--- a/RacingAidWpf/View/MainWindow.xaml
+++ b/RacingAidWpf/View/MainWindow.xaml
@@ -38,11 +38,22 @@
                     Command="{Binding StopCommand}"
                     IsEnabled="{Binding IsStarted}"/>
             <ToggleButton x:Name="RepositionButton"
-                          Height="25" Width="120"
-                          Margin="10, 0, 0, 0"
-                          Content="Enable Reposition"
-                          Command="{Binding MoveOverlaysToggleCommand}"
-                          IsEnabled="{Binding IsStarted}"/>
+              Height="25" Width="120"
+              Margin="10, 0, 0, 0"
+              IsChecked="{Binding IsRepositionEnabled}" 
+              IsEnabled="{Binding IsStarted}">
+            <ToggleButton.Style>
+                <Style TargetType="ToggleButton">
+                    <Setter Property="Content" Value="Enable Reposition" />
+                    <Style.Triggers>
+                        <DataTrigger Binding="{Binding IsRepositionEnabled}" Value="True">
+                            <Setter Property="Content" Value="Disable Reposition" />
+                        </DataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </ToggleButton.Style>
+        </ToggleButton>
+
         </StackPanel>
         
         <GroupBox Grid.Row="1" Grid.Column="0" Header="General" MinHeight="100" MinWidth="165">

--- a/RacingAidWpf/View/MainWindow.xaml
+++ b/RacingAidWpf/View/MainWindow.xaml
@@ -49,6 +49,9 @@
                         <DataTrigger Binding="{Binding IsRepositionEnabled}" Value="True">
                             <Setter Property="Content" Value="Disable Reposition" />
                         </DataTrigger>
+                        <DataTrigger Binding="{Binding IsRepositionEnabled}" Value="False">
+                            <Setter Property="Content" Value="Enable Reposition" />
+                        </DataTrigger>
                     </Style.Triggers>
                 </Style>
             </ToggleButton.Style>

--- a/RacingAidWpf/ViewModel/MainWindowViewModel.cs
+++ b/RacingAidWpf/ViewModel/MainWindowViewModel.cs
@@ -14,9 +14,7 @@ public sealed class MainWindowViewModel : NotifyPropertyChanged
     private readonly TimesheetConfigSection timesheetConfigSection = ConfigSectionSingleton.TimesheetSection;
     private readonly RelativeConfigSection relativeConfigSection = ConfigSectionSingleton.RelativeSection;
     private readonly TelemetryConfigSection telemetryConfigSection = ConfigSectionSingleton.TelemetrySection;
-
-    // Exposing this as public for the Tests
-    public readonly OverlayController overlayController;
+    private readonly OverlayController overlayController;
 
     public ICommand StartCommand { get; }
     public ICommand StopCommand { get; }

--- a/RacingAidWpf/ViewModel/MainWindowViewModel.cs
+++ b/RacingAidWpf/ViewModel/MainWindowViewModel.cs
@@ -14,9 +14,10 @@ public sealed class MainWindowViewModel : NotifyPropertyChanged
     private readonly TimesheetConfigSection timesheetConfigSection = ConfigSectionSingleton.TimesheetSection;
     private readonly RelativeConfigSection relativeConfigSection = ConfigSectionSingleton.RelativeSection;
     private readonly TelemetryConfigSection telemetryConfigSection = ConfigSectionSingleton.TelemetrySection;
-    
-    private readonly OverlayController overlayController;
-    
+
+    // Exposing this as public for the Tests
+    public readonly OverlayController overlayController;
+
     public ICommand StartCommand { get; }
     public ICommand StopCommand { get; }
     public ICommand MoveOverlaysToggleCommand { get; }
@@ -32,11 +33,11 @@ public sealed class MainWindowViewModel : NotifyPropertyChanged
             OnPropertyChanged(nameof(IsStopped));
         }
     }
-    
+
     public bool IsStopped => !IsStarted;
 
     public ObservableCollection<SimulatorEntryModel> SimulatorEntryCollection { get; private set; }
-    
+
     private SimulatorEntryModel selectedSimulatorEntry = new("N/A", Simulator.Unknown);
 
     public SimulatorEntryModel SelectedSimulatorEntry
@@ -51,11 +52,11 @@ public sealed class MainWindowViewModel : NotifyPropertyChanged
             OnPropertyChanged();
         }
     }
-    
+
     #region Config properties
-    
+
     #region General
-    
+
     public int UpdateIntervalMs
     {
         get => generalConfigSection.UpdateIntervalMs;
@@ -68,11 +69,11 @@ public sealed class MainWindowViewModel : NotifyPropertyChanged
             OnPropertyChanged();
         }
     }
-    
+
     #endregion
-    
+
     #region Timesheet
-    
+
     public bool DisplayCarNumber
     {
         get => timesheetConfigSection.DisplayCarNumber;
@@ -80,7 +81,7 @@ public sealed class MainWindowViewModel : NotifyPropertyChanged
         {
             if (timesheetConfigSection.DisplayCarNumber == value)
                 return;
-            
+
             timesheetConfigSection.DisplayCarNumber = value;
             OnPropertyChanged();
         }
@@ -93,12 +94,12 @@ public sealed class MainWindowViewModel : NotifyPropertyChanged
         {
             if (timesheetConfigSection.DisplaySafetyRating == value)
                 return;
-            
+
             timesheetConfigSection.DisplaySafetyRating = value;
             OnPropertyChanged();
         }
     }
-    
+
     public bool DisplaySkillRating
     {
         get => timesheetConfigSection.DisplaySkillRating;
@@ -106,12 +107,12 @@ public sealed class MainWindowViewModel : NotifyPropertyChanged
         {
             if (timesheetConfigSection.DisplaySkillRating == value)
                 return;
-            
+
             timesheetConfigSection.DisplaySkillRating = value;
             OnPropertyChanged();
         }
     }
-    
+
     public bool DisplayLastLap
     {
         get => timesheetConfigSection.DisplayLastLap;
@@ -119,12 +120,12 @@ public sealed class MainWindowViewModel : NotifyPropertyChanged
         {
             if (timesheetConfigSection.DisplayLastLap == value)
                 return;
-            
+
             timesheetConfigSection.DisplayLastLap = value;
             OnPropertyChanged();
         }
     }
-    
+
     public bool DisplayFastestLap
     {
         get => timesheetConfigSection.DisplayFastestLap;
@@ -132,12 +133,12 @@ public sealed class MainWindowViewModel : NotifyPropertyChanged
         {
             if (timesheetConfigSection.DisplayFastestLap == value)
                 return;
-            
+
             timesheetConfigSection.DisplayFastestLap = value;
             OnPropertyChanged();
         }
     }
-    
+
     public bool DisplayGapToLeader
     {
         get => timesheetConfigSection.DisplayGapToLeader;
@@ -145,16 +146,16 @@ public sealed class MainWindowViewModel : NotifyPropertyChanged
         {
             if (timesheetConfigSection.DisplayGapToLeader == value)
                 return;
-            
+
             timesheetConfigSection.DisplayGapToLeader = value;
             OnPropertyChanged();
         }
     }
-    
+
     #endregion
-    
+
     #region Relative
-    
+
     public bool DisplayRelativeCarNumber
     {
         get => relativeConfigSection.DisplayCarNumber;
@@ -162,7 +163,7 @@ public sealed class MainWindowViewModel : NotifyPropertyChanged
         {
             if (relativeConfigSection.DisplayCarNumber == value)
                 return;
-            
+
             relativeConfigSection.DisplayCarNumber = value;
             OnPropertyChanged();
         }
@@ -175,12 +176,12 @@ public sealed class MainWindowViewModel : NotifyPropertyChanged
         {
             if (relativeConfigSection.DisplaySafetyRating == value)
                 return;
-            
+
             relativeConfigSection.DisplaySafetyRating = value;
             OnPropertyChanged();
         }
     }
-    
+
     public bool DisplayRelativeSkillRating
     {
         get => relativeConfigSection.DisplaySkillRating;
@@ -188,12 +189,12 @@ public sealed class MainWindowViewModel : NotifyPropertyChanged
         {
             if (relativeConfigSection.DisplaySkillRating == value)
                 return;
-            
+
             relativeConfigSection.DisplaySkillRating = value;
             OnPropertyChanged();
         }
     }
-    
+
     public bool DisplayRelativeLastLap
     {
         get => relativeConfigSection.DisplayLastLap;
@@ -201,12 +202,12 @@ public sealed class MainWindowViewModel : NotifyPropertyChanged
         {
             if (relativeConfigSection.DisplayLastLap == value)
                 return;
-            
+
             relativeConfigSection.DisplayLastLap = value;
             OnPropertyChanged();
         }
     }
-    
+
     public bool DisplayRelativeFastestLap
     {
         get => relativeConfigSection.DisplayFastestLap;
@@ -214,12 +215,12 @@ public sealed class MainWindowViewModel : NotifyPropertyChanged
         {
             if (relativeConfigSection.DisplayFastestLap == value)
                 return;
-            
+
             relativeConfigSection.DisplayFastestLap = value;
             OnPropertyChanged();
         }
     }
-    
+
     public bool DisplayRelativeDelta
     {
         get => relativeConfigSection.DisplayGapToLocal;
@@ -227,16 +228,16 @@ public sealed class MainWindowViewModel : NotifyPropertyChanged
         {
             if (relativeConfigSection.DisplayGapToLocal == value)
                 return;
-            
+
             relativeConfigSection.DisplayGapToLocal = value;
             OnPropertyChanged();
         }
     }
-    
+
     #endregion
-    
+
     #region Telemetry
-    
+
     public bool UseMetricUnits
     {
         get => telemetryConfigSection.UseMetricUnits;
@@ -244,24 +245,40 @@ public sealed class MainWindowViewModel : NotifyPropertyChanged
         {
             if (telemetryConfigSection.UseMetricUnits == value)
                 return;
-            
+
             telemetryConfigSection.UseMetricUnits = value;
             OnPropertyChanged();
         }
     }
-    
+
     #endregion
-    
+
     #endregion
-    
-    
-    public MainWindowViewModel()
+
+    #region Reposition Button Logic
+
+    public bool IsRepositionEnabled
     {
-        overlayController = new OverlayController();
+        get => overlayController.IsRepositioningEnabled;
+        set
+        {
+            if (overlayController.IsRepositioningEnabled != value)
+            {
+                overlayController.IsRepositioningEnabled = value;
+                OnPropertyChanged();
+            }
+        }
+    }
+
+    #endregion
+
+    public MainWindowViewModel(OverlayController? injectedOverlayController = null)
+    {
+        overlayController = injectedOverlayController ?? new OverlayController();
         overlayController.AddOverlay(new TelemetryOverlay());
         overlayController.AddOverlay(new TimesheetOverlay());
         overlayController.AddOverlay(new RelativeOverlay());
-            
+
         var simulatorEntries = new List<SimulatorEntryModel>
         {
             new(Enum.GetName(Simulator.iRacing), Simulator.iRacing),
@@ -270,7 +287,7 @@ public sealed class MainWindowViewModel : NotifyPropertyChanged
 
         SimulatorEntryCollection = new ObservableCollection<SimulatorEntryModel>(simulatorEntries);
         SelectedSimulatorEntry = simulatorEntries.First();
-        
+
         StartCommand = new Command(Start);
         StopCommand = new Command(Stop);
         MoveOverlaysToggleCommand = new Command(ToggleOverlayRepositioning);
@@ -282,32 +299,34 @@ public sealed class MainWindowViewModel : NotifyPropertyChanged
         overlayController.CloseAll();
     }
 
-    private void Start()
+    public void Start()
     {
         IsStarted = true;
-        
+
         RacingAidSingleton.Instance.SetupSimulator(SelectedSimulatorEntry.SimulatorType);
         RacingAidSingleton.Instance.Start();
 
         RacingAidUpdateDispatch.Start();
-        
+
         overlayController.ShowAll();
     }
 
-    private void Stop()
+    public void Stop()
     {
         RacingAidSingleton.Instance.Stop();
         RacingAidUpdateDispatch.Stop();
 
-        overlayController.IsRepositioningEnabled = false;
+        IsRepositionEnabled = false;
         overlayController.HideAll();
 
         IsStarted = false;
     }
 
-    private void ToggleOverlayRepositioning()
+    public void ToggleOverlayRepositioning()
     {
         if (IsStarted)
-            overlayController.IsRepositioningEnabled = !overlayController.IsRepositioningEnabled;
+        {
+            IsRepositionEnabled = !IsRepositionEnabled;
+        }
     }
 }


### PR DESCRIPTION
# Pull Request Description

### Summary
This pull request introduces several enhancements and fixes to the RacingAid project. Key changes include updates to the project file, addition of new tests, and improvements to the overlay management and view model logic.

### Changes Made
- **Project File Updates (`RacingAidTests.csproj`):**
  - Updated `TargetFramework` to `net8.0-windows7.0`.
  - Added a project reference to `RacingAidWpf.csproj`.
  - Included `Moq` package for mocking in tests.

- **New Tests (`MainWindowViewModelTests.cs`):**
  - Added tests for `MainWindowViewModel` using NUnit and Moq.
  - Tests cover methods like `ToggleOverlayRepositioning`, ensuring properties are toggled correctly and events are raised.

- **Overlay Management (`OverlayController.cs`):**
  - Marked `IsRepositioningEnabled` and `AddOverlay` methods as virtual for better testability.

- **View Updates (`MainWindow.xaml`):**
  - Improved `ToggleButton` for repositioning overlays with dynamic content based on the state.

- **ViewModel Enhancements (`MainWindowViewModel.cs`):**
  - Exposed `OverlayController` as public for testing.
  - Added `IsRepositionEnabled` property to handle overlay repositioning logic.
  - Updated methods to toggle `IsRepositionEnabled` correctly.

### Detailed Changes
- **ViewModel Updates:**
  - Made `Start`, `Stop`, and `ToggleOverlayRepositioning` methods public.
  - Added properties to manage configuration settings with proper change notifications.

- **Configuration Clean-Up (`Config.cs`):**
  - Fixed formatting issues and ensured consistent code style.


![image](https://github.com/user-attachments/assets/3e0e619c-4243-4733-b2ea-36b206283184)
![image](https://github.com/user-attachments/assets/f34da724-99ec-419a-91ff-b6652d9b9495)

