### PR TITLE
RA-18 - move config folder

### DIFF
--- a/RacingAidTests/iRacingDataDeserializerTests.cs
+++ b/RacingAidTests/iRacingDataDeserializerTests.cs
@@ -1,6 +1,4 @@
-﻿using IRSDKSharper;
-
-namespace RacingAidTests;
+﻿namespace RacingAidTests;
 
 public class iRacingDataDeserializerTests
 {

--- a/RacingAidWpf/Configuration/Config.cs
+++ b/RacingAidWpf/Configuration/Config.cs
@@ -1,5 +1,4 @@
-﻿using System.ComponentModel;
-using System.IO;
+﻿using System.IO;
 using Salaros.Configuration;
 
 namespace RacingAidWpf.Configuration;
@@ -19,8 +18,8 @@ public class Config : IConfig
     public bool TryGetBool(string section, string key, out bool? value)
     {
         value = null;
-        if (configParser.GetValue(section, key, true) is { } configValue)
-            value = configValue;
+        if (TryGetString(section, key, out var strValue) && bool.TryParse(strValue, out var boolValue))
+            value = boolValue;
 
         return value != null;
     }
@@ -28,8 +27,8 @@ public class Config : IConfig
     public bool TryGetInt(string section, string key, out int? value)
     {
         value = null;
-        if (configParser.GetValue(section, key, 0) is { } configValue)
-            value = configValue;
+        if (TryGetString(section, key, out var strValue) && int.TryParse(strValue, out var intValue))
+            value = intValue;
 
         return value.HasValue;
     }
@@ -37,8 +36,8 @@ public class Config : IConfig
     public bool TryGetDouble(string section, string key, out double? value)
     {
         value = null;
-        if (configParser.GetValue(section, key, 0d) is { } configValue)
-            value = configValue;
+        if (TryGetString(section, key, out var strValue) && double.TryParse(strValue, out var doubleValue))
+            value = doubleValue;
 
         return value.HasValue;
     }

--- a/RacingAidWpf/Configuration/ConfigSectionSingleton.cs
+++ b/RacingAidWpf/Configuration/ConfigSectionSingleton.cs
@@ -1,12 +1,14 @@
 ﻿using System.IO;
-using System.Windows;
+using RacingAidWpf.Resources;
 
 namespace RacingAidWpf.Configuration;
 
 public static class ConfigSectionSingleton
 {
-    private static readonly string ConfigFilePath = Path.Combine(Path.GetDirectoryName(Application.ResourceAssembly.Location) ?? string.Empty, "config.ini");
-    private static Config Config => new(ConfigFilePath);
+    private static readonly string ConfigFilePath = Path.Combine(Resource.DataDirectory, "config.ini");
+    
+    private static Config? config;
+    private static Config Config => config ??= new Config(ConfigFilePath);
     
     private static GeneralConfigSection? generalSection;
     public static GeneralConfigSection GeneralSection =>

--- a/RacingAidWpf/Extensions/TelemetryExtensions.cs
+++ b/RacingAidWpf/Extensions/TelemetryExtensions.cs
@@ -1,6 +1,4 @@
-﻿using System.Globalization;
-
-namespace RacingAidWpf.Extensions;
+﻿namespace RacingAidWpf.Extensions;
 
 public static class TelemetryExtensions
 {

--- a/RacingAidWpf/OverlayManagement/OverlayController.cs
+++ b/RacingAidWpf/OverlayManagement/OverlayController.cs
@@ -6,10 +6,8 @@ namespace RacingAidWpf.OverlayManagement;
 
 public class OverlayController
 {
-    private static readonly string OverlayPositionsJsonDirectory =
-        Path.Combine(Resource.ExecutingDirectory, "Overlays");
     private static readonly string OverlayPositionsJsonFullPath =
-        Path.Combine(OverlayPositionsJsonDirectory, "OverlayPositions.json");
+        Path.Combine(Resource.DataDirectory, "OverlayPositions.json");
     
     private readonly List<Overlay> overlays = [];
     private bool isRepositionEnabled;
@@ -90,15 +88,10 @@ public class OverlayController
 
     private void SaveOverlayPositions()
     {
-        List<OverlayPosition> overlayPositions = overlays.Select(CreateOverlayPosition).ToList();
+        var overlayPositions = overlays.Select(CreateOverlayPosition).ToList();
 
         if (JsonConvert.SerializeObject(overlayPositions, Formatting.Indented) is { } overlayPositionsJsonString)
-        {
-            if (!Directory.Exists(OverlayPositionsJsonDirectory))
-                Directory.CreateDirectory(OverlayPositionsJsonDirectory);
-            
             File.WriteAllTextAsync(OverlayPositionsJsonFullPath, overlayPositionsJsonString);
-        }
     }
 
     private static OverlayPosition CreateOverlayPosition(Overlay overlay) =>

--- a/RacingAidWpf/Resources/Resource.cs
+++ b/RacingAidWpf/Resources/Resource.cs
@@ -5,15 +5,23 @@ namespace RacingAidWpf.Resources;
 
 public static class Resource
 {
-    public static string ExecutingDirectory =>
-        Path.GetDirectoryName(ExecutingAssembly.Location) ?? Directory.GetCurrentDirectory();
-    
+    private const string SubDirectoryName = "RacingAid";
+    public static string DataDirectory
+    {
+        get
+        {
+            var dataDirectory = Path.Combine(AppDataDirectory, SubDirectoryName);
+            
+            if (!Directory.Exists(dataDirectory))
+                Directory.CreateDirectory(dataDirectory);
+            
+            return dataDirectory;
+        }
+    }
     public static Uri SteeringWheelUri => GetImageUri("SteeringWheel.png");
     
-    private static readonly string AssemblyPath =
-        $"pack://application:,,,/{ExecutingAssembly.GetName().Name};component/Resources";
-
     private static Assembly ExecutingAssembly => Assembly.GetExecutingAssembly();
-
+    private static string AssemblyPath => $"pack://application:,,,/{ExecutingAssembly.GetName().Name};component/Resources";
+    private static string AppDataDirectory => Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
     private static Uri GetImageUri(string imageName) => new($"{AssemblyPath}/Images/{imageName}");
 }


### PR DESCRIPTION
Moved the default configs folder to AppData.

I've also fixed an issue with the config reader where it was trying to create a new ConfigParser for every ConfigSection which was causing it to only save data for a single section every time you ran the application.