### PR TITLE
Fixing exe to single file for windows-x64

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,10 +22,10 @@ jobs:
       run: dotnet restore
 
     - name: Build the project
-      run: dotnet build --configuration Release
+      run: dotnet build -c Release
 
     - name: Publish the project
-      run: dotnet publish -c Release -r win-x64 --self-contained -p:PublishSingleFile=true -o out
+      run: dotnet publish ./RacingAidWpf/RacingAidWpf.csproj -c Release -r win-x64 --self-contained -p:PublishSingleFile=true -o out
 
     - name: Upload artifact
       uses: actions/upload-artifact@v3

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,7 +25,7 @@ jobs:
       run: dotnet build --configuration Release
 
     - name: Publish the project
-      run: dotnet publish -c Release -o out
+      run: dotnet publish -c Release -r win-x64 --self-contained -p:PublishSingleFile=true -o out
 
     - name: Upload artifact
       uses: actions/upload-artifact@v3


### PR DESCRIPTION
Here is a draft for the PR description:

---

## Description

This PR addresses the issues related to building the executable file for the `RacingAid` project. The main focus of these changes is to ensure the executable is correctly built as a single file for `windows-x64`.

## Changes Made
- Updated the build process to fix the executable build issues.
- Ensured the executable is built as a single file for the `windows-x64` platform.

## Impact
These changes ensure that the executable is correctly built and packaged, improving the usability and deployment process of the `RacingAid` project.

## How to Test
1. Clone the repository.
2. Switch to the `FixingExeBuild` branch.
3. Build the project using Visual Studio.
4. Verify that the executable is built as a single file for the `windows-x64` platform.

---

Feel free to modify and expand upon this draft to better fit your needs.