### PR TITLE
RA-20 - Display drivers on track map

### DIFF
--- a/RacingAidData/Simulators/iRacing/iRacingDataDeserializer.cs
+++ b/RacingAidData/Simulators/iRacing/iRacingDataDeserializer.cs
@@ -98,7 +98,7 @@ public class iRacingDataDeserializer : IDeserializeData
                 SafetyRating = driver.LicString,
                 OverallPosition = resultPosition.Position,
                 ClassPosition = resultPosition.ClassPosition,
-                LapsDriven = (int)resultPosition.LapsDriven,
+                LapsDriven = GetLapsDriven(iRacingData, carIdx),
                 LastLapMs = (int)(resultPosition.LastTime * 1000),
                 FastestLapMs = (int)(resultPosition.FastestTime * 1000),
                 GapToLeaderMs = gapToLeaderMs,
@@ -143,7 +143,7 @@ public class iRacingDataDeserializer : IDeserializeData
                 SafetyRating = driver.LicString,
                 OverallPosition = GetOverallPosition(iRacingData, carIdx), // might not have a 'result' yet
                 ClassPosition = GetClassPosition(iRacingData, carIdx), // might not have a 'result' yet
-                LapsDriven = hasResult ? resultPosition.LapsDriven : 0,
+                LapsDriven = GetLapsDriven(iRacingData, carIdx),
                 LastLapMs = hasResult ? (int)(resultPosition.LastTime * 1000) : 0,
                 FastestLapMs = hasResult ? (int)(resultPosition.FastestTime * 1000) : 0,
                 GapToLocalMs = GetGapToLocalMs(iRacingData, localCarIdx, carIdx),

--- a/RacingAidWpf/Tracks/DriverTrackVisualization.cs
+++ b/RacingAidWpf/Tracks/DriverTrackVisualization.cs
@@ -1,0 +1,14 @@
+﻿using System.Windows.Media;
+
+namespace RacingAidWpf.Tracks;
+
+public class DriverTrackVisualization(double x, double y, double radius, int number, Brush fill, Brush border, double borderThickness)
+{
+    public double X { get; set; } = x;
+    public double Y { get; set; } = y;
+    public double Radius { get; set; } = radius;
+    public int Number { get; set; } = number;
+    public Brush Fill { get; set; } = fill;
+    public Brush Border { get; set; } = border;
+    public double BorderThickness { get; set; } = borderThickness;
+}

--- a/RacingAidWpf/Tracks/TrackMapPathCreator.cs
+++ b/RacingAidWpf/Tracks/TrackMapPathCreator.cs
@@ -5,6 +5,19 @@ namespace RacingAidWpf.Tracks;
 
 public static class TrackMapPathCreator
 {
+    public static List<TrackMapPosition> GetScaledTrackMapPositions(TrackMap trackMap, float factor)
+    {
+        var positions = trackMap.Positions;
+        
+        factor *= CalculateScalingFactor(trackMap);
+
+        var yMax = positions.Max(p => p.Y);
+
+        return positions
+            .Select(position => new TrackMapPosition(position.X * factor, (yMax - position.Y) * factor))
+            .ToList();
+    }
+    
     public static GeometryGroup CreateGeometryGroupFromTrackMap(TrackMap trackMap, float factor)
     {
         var geometryGroup = new GeometryGroup();
@@ -12,25 +25,53 @@ public static class TrackMapPathCreator
         var positions = trackMap.Positions;
         var nPositions = positions.Count;
 
-        var yRange = positions.Max(p => p.Y) - positions.Min(p => p.Y);
-        var xRange = positions.Max(p => p.X) - - positions.Min(p => p.X);
-        
-        factor = yRange > xRange ? factor / yRange : factor / xRange;
-        
-        // apply padding
-        factor *= 0.95f;
+        var yMax = positions.Max(p => p.Y);
+
+        factor *= CalculateScalingFactor(trackMap);
 
         for (var i = 1; i < nPositions; i++)
         {
             var previousPosition = positions[i - 1];
             var currentPosition = positions[i];
             
-            var startPoint = new Point(previousPosition.X * factor, (yRange - previousPosition.Y) * factor);
-            var endPoint = new Point(currentPosition.X * factor, (yRange - currentPosition.Y) * factor);
+            var startPoint = new Point(previousPosition.X * factor, (yMax - previousPosition.Y) * factor);
+            var endPoint = new Point(currentPosition.X * factor, (yMax - currentPosition.Y) * factor);
 
             geometryGroup.Children.Add(new LineGeometry(startPoint, endPoint));
         }
         
         return geometryGroup;
+    }
+
+    private static float CalculateScalingFactor(TrackMap trackMap)
+    {
+        var positions = trackMap.Positions;
+
+        var yMax = 0f;
+        var yMin = 0f;
+        var xMax = 0f;
+        var xMin = 0f;
+        
+        foreach (var position in positions)
+        {
+            if (position.Y > yMax)
+                yMax = position.Y;
+            
+            if (position.Y < yMin)
+                yMin = position.Y;
+            
+            if (position.X > xMax)
+                xMax = position.X;
+            
+            if (position.X < xMin)
+                xMin = position.X;
+        }
+
+        var yRange = yMax - yMin;
+        var xRange = xMax - xMin;
+        var max = yRange > xRange ? yRange : xRange;
+
+        // 0.95 to act as 'padding'
+        return 0.95f / max;
     }
 }

--- a/RacingAidWpf/View/TrackMapOverlay.xaml
+++ b/RacingAidWpf/View/TrackMapOverlay.xaml
@@ -34,17 +34,24 @@
             </ItemsControl.ItemsPanel>
             <ItemsControl.ItemTemplate>
                 <DataTemplate>
-                    <Ellipse Width="{Binding Radius}"
-                             Height="{Binding Radius}"
-                             StrokeThickness="{Binding BorderThickness}"
-                             Stroke="{Binding Border}"
-                             Fill="{Binding Fill}">
-                        <Ellipse.RenderTransform>
-                            <TranslateTransform X="{Binding X}" Y="{Binding Y}"/>
-                        </Ellipse.RenderTransform>
-                    </Ellipse>
+                    <Grid>
+                        <Ellipse Width="{Binding Radius}"
+                                 Height="{Binding Radius}"
+                                 StrokeThickness="{Binding BorderThickness}"
+                                 Stroke="{Binding Border}"
+                                 Fill="{Binding Fill}">
+                        </Ellipse>
+                        <TextBlock Text="{Binding Number}" FontSize="10" Foreground="Black" HorizontalAlignment="Center" VerticalAlignment="Center" />
+                    </Grid>
                 </DataTemplate>
             </ItemsControl.ItemTemplate>
+            <ItemsControl.ItemContainerStyle>
+                <Style TargetType="ContentPresenter">
+                    <Setter Property="Canvas.Left" Value="{Binding X}"/>
+                    <Setter Property="Canvas.Top" Value="{Binding Y}"/>
+                </Style>
+            </ItemsControl.ItemContainerStyle>
+            
         </ItemsControl>
     </Grid>
 </overlays:Overlay>

--- a/RacingAidWpf/View/TrackMapOverlay.xaml
+++ b/RacingAidWpf/View/TrackMapOverlay.xaml
@@ -16,21 +16,16 @@
     <overlays:Overlay.Background>
         <SolidColorBrush Color="Transparent"/>
     </overlays:Overlay.Background>
-    <Grid>
-        <!-- For some reason I'm not sure about, adding this Canvas here is resolving some discrepancies in size between the track and driver visualizations -->
-        <Canvas Style="{StaticResource DefaultCanvasStyle}" Opacity="0.1"/>
-        
-        <TextBlock Text="Track Map unavailable - please complete valid lap" 
+    <Grid Margin="10">
+        <TextBlock Text="Track Map unavailable - please complete valid lap"
                    Style="{StaticResource DefaultTextBlock}"
                    TextWrapping="Wrap"
                    Visibility="{Binding NoTrackMapTextVisibility}"/>
-        
         <Path Data="{Binding TrackMapPathData}"
               Stroke="DarkGray"
               StrokeThickness="5"
-              Margin="10"
               Visibility="{Binding TrackMapVisibility}"/>
-            
+        
         <ItemsControl ItemsSource="{Binding DriverTrackVisualizations}">
             <ItemsControl.ItemsPanel>
                 <ItemsPanelTemplate>

--- a/RacingAidWpf/View/TrackMapOverlay.xaml
+++ b/RacingAidWpf/View/TrackMapOverlay.xaml
@@ -5,6 +5,7 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:viewModel="clr-namespace:RacingAidWpf.ViewModel"
         xmlns:overlays="clr-namespace:RacingAidWpf.Overlays"
+        xmlns:converters="clr-namespace:RacingAidWpf.Converters"
         mc:Ignorable="d"
         d:DataContext="{d:DesignInstance viewModel:TrackMapOverlayViewModel}"
         Title="Track Map"
@@ -13,7 +14,10 @@
         Topmost="True"
         AllowsTransparency="True"
         MouseLeftButtonDown="OnMouseLeftButtonDown">
-    <overlays:Overlay.Background>
+    <overlays:Overlay.Resources>
+        <converters:PositionConverter x:Key="PositionConverter"/>
+    </overlays:Overlay.Resources>
+        <overlays:Overlay.Background>
         <SolidColorBrush Color="Transparent"/>
     </overlays:Overlay.Background>
     <Grid Margin="10">
@@ -41,7 +45,7 @@
                                  Stroke="{Binding Border}"
                                  Fill="{Binding Fill}">
                         </Ellipse>
-                        <TextBlock Text="{Binding Number}" FontSize="10" Foreground="Black" HorizontalAlignment="Center" VerticalAlignment="Center" />
+                        <TextBlock Text="{Binding Number, Converter={StaticResource PositionConverter}}" FontSize="10" Foreground="Black" HorizontalAlignment="Center" VerticalAlignment="Center" />
                     </Grid>
                 </DataTemplate>
             </ItemsControl.ItemTemplate>
@@ -51,7 +55,6 @@
                     <Setter Property="Canvas.Top" Value="{Binding Y}"/>
                 </Style>
             </ItemsControl.ItemContainerStyle>
-            
         </ItemsControl>
     </Grid>
 </overlays:Overlay>

--- a/RacingAidWpf/View/TrackMapOverlay.xaml
+++ b/RacingAidWpf/View/TrackMapOverlay.xaml
@@ -16,17 +16,40 @@
     <overlays:Overlay.Background>
         <SolidColorBrush Color="Transparent"/>
     </overlays:Overlay.Background>
-    <Grid HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+    <Grid>
+        <!-- For some reason I'm not sure about, adding this Canvas here is resolving some discrepancies in size between the track and driver visualizations -->
+        <Canvas Style="{StaticResource DefaultCanvasStyle}" Opacity="0.1"/>
+        
         <TextBlock Text="Track Map unavailable - please complete valid lap" 
                    Style="{StaticResource DefaultTextBlock}"
                    TextWrapping="Wrap"
                    Visibility="{Binding NoTrackMapTextVisibility}"/>
-            <Path Data="{Binding TrackMapPathData}"
-                  Stroke="DarkGray"
-                  StrokeThickness="5"
-                  Margin="10"
-                  HorizontalAlignment="Center"
-                  VerticalAlignment="Center"
-                  Visibility="{Binding TrackMapVisibility}"/>
+        
+        <Path Data="{Binding TrackMapPathData}"
+              Stroke="DarkGray"
+              StrokeThickness="5"
+              Margin="10"
+              Visibility="{Binding TrackMapVisibility}"/>
+            
+        <ItemsControl ItemsSource="{Binding DriverTrackVisualizations}">
+            <ItemsControl.ItemsPanel>
+                <ItemsPanelTemplate>
+                    <Canvas/>
+                </ItemsPanelTemplate>
+            </ItemsControl.ItemsPanel>
+            <ItemsControl.ItemTemplate>
+                <DataTemplate>
+                    <Ellipse Width="{Binding Radius}"
+                             Height="{Binding Radius}"
+                             StrokeThickness="{Binding BorderThickness}"
+                             Stroke="{Binding Border}"
+                             Fill="{Binding Fill}">
+                        <Ellipse.RenderTransform>
+                            <TranslateTransform X="{Binding X}" Y="{Binding Y}"/>
+                        </Ellipse.RenderTransform>
+                    </Ellipse>
+                </DataTemplate>
+            </ItemsControl.ItemTemplate>
+        </ItemsControl>
     </Grid>
 </overlays:Overlay>

--- a/RacingAidWpf/ViewModel/TrackMapOverlayViewModel.cs
+++ b/RacingAidWpf/ViewModel/TrackMapOverlayViewModel.cs
@@ -12,7 +12,7 @@ public class TrackMapOverlayViewModel : ViewModel
     
     private readonly TrackMapController trackMapController;
     private readonly TrackMapCreator trackMapCreator;
-    
+
     private string currentTrackName;
     private string CurrentTrackName
     {
@@ -122,25 +122,27 @@ public class TrackMapOverlayViewModel : ViewModel
     {
         var scaledPositions = TrackMapPathCreator.GetScaledTrackMapPositions(currentTrackMap, TargetSize);
         var nPositions = scaledPositions.Count;
-        
+
         var visualizations = new ObservableCollection<DriverTrackVisualization>();
         
         foreach (var driver in RacingAidSingleton.Instance.Relative.Entries)
         {
             var lapsDriven = driver.LapsDriven;
             var lapPercentage = lapsDriven - (int)lapsDriven;
-
+        
             var positionIndexRelativeToLapPercentage = (int)(lapPercentage * nPositions);
             var position = scaledPositions[positionIndexRelativeToLapPercentage];
-
+        
             var fillColor = driver.IsLocal ? Brushes.Red : Brushes.LightGray;
             var borderColor = driver.IsLocal ? Brushes.WhiteSmoke : Brushes.LightGray;   
             var size = driver.IsLocal ? 20d : 15d;
             
             // TODO: update number based on number display type (overall, class, car number)
             var number = driver.OverallPosition;
-
-            visualizations.Add(new DriverTrackVisualization(position.X, position.Y, size, number, fillColor, borderColor, 2d));
+        
+            // Canvas positions place visualizations based on top left not centre, so to get centre of ellipse subtract half size in x and y
+            var halfSize = size / 2d; 
+            visualizations.Add(new DriverTrackVisualization(position.X - halfSize, position.Y - halfSize, size, number, fillColor, borderColor, 2d));
         }
         
         DriverTrackVisualizations = visualizations;

--- a/RacingAidWpf/ViewModel/TrackMapOverlayViewModel.cs
+++ b/RacingAidWpf/ViewModel/TrackMapOverlayViewModel.cs
@@ -1,4 +1,5 @@
-﻿using System.Windows;
+﻿using System.Collections.ObjectModel;
+using System.Windows;
 using System.Windows.Media;
 using RacingAidWpf.FileHandlers;
 using RacingAidWpf.Tracks;
@@ -25,23 +26,40 @@ public class TrackMapOverlayViewModel : ViewModel
             OnTrackChanged();
         }
     }
-
-    private GeometryGroup trackMapPathData;
-    public GeometryGroup TrackMapPathData
+    
+    private TrackMap currentTrackMap;
+    private TrackMap CurrentTrackMap
     {
-        get => trackMapPathData;
+        get => currentTrackMap;
         set
         {
-            if (trackMapPathData == value)
+            if (currentTrackMap == value)
                 return;
             
-            trackMapPathData = value;
+            currentTrackMap = value;
             OnPropertyChanged();
+            OnPropertyChanged(nameof(TrackMapPathData));
             OnPropertyChanged(nameof(IsTrackMapAvailable));
             OnPropertyChanged(nameof(TrackMapVisibility));
             OnPropertyChanged(nameof(NoTrackMapTextVisibility));
         }
     }
+    
+    private ObservableCollection<DriverTrackVisualization> driverTrackVisualizations = [];
+    public ObservableCollection<DriverTrackVisualization> DriverTrackVisualizations
+    {
+        get => driverTrackVisualizations;
+        set
+        {
+            if (driverTrackVisualizations == value)
+                return;
+            
+            driverTrackVisualizations = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public GeometryGroup TrackMapPathData => CurrentTrackMap == null ? null : TrackMapPathCreator.CreateGeometryGroupFromTrackMap(CurrentTrackMap, TargetSize);
     
     public bool IsTrackMapAvailable => TrackMapPathData != null;
 
@@ -68,7 +86,7 @@ public class TrackMapOverlayViewModel : ViewModel
     {
         CurrentTrackName = RacingAidSingleton.Instance.TrackData.TrackName;
 
-        if (TrackMapPathData != null)
+        if (CurrentTrackMap != null)
             UpdateDriverPositionsOnTrack();
 
         if (trackMapCreator.IsStarted)
@@ -84,11 +102,11 @@ public class TrackMapOverlayViewModel : ViewModel
         
         if (trackMapController.TryGetTrackMap(CurrentTrackName, out var trackMap))
         {
-            UpdateTrackMapPathData(trackMap);
+            CurrentTrackMap = trackMap;
             return;
         }
         
-        TrackMapPathData = null;
+        CurrentTrackMap = null;
         trackMapCreator.Start(RacingAidSingleton.Instance.DriverData, RacingAidSingleton.Instance.TrackData);
     }
 
@@ -97,16 +115,34 @@ public class TrackMapOverlayViewModel : ViewModel
         Console.WriteLine($"Track created: {trackMap.Name}");
         
         trackMapController.AddTrackMap(trackMap);
-        UpdateTrackMapPathData(trackMap);
+        CurrentTrackMap = trackMap;
     }
 
     private void UpdateDriverPositionsOnTrack()
     {
-        // TODO
-    }
+        var scaledPositions = TrackMapPathCreator.GetScaledTrackMapPositions(currentTrackMap, TargetSize);
+        var nPositions = scaledPositions.Count;
+        
+        var visualizations = new ObservableCollection<DriverTrackVisualization>();
+        
+        foreach (var driver in RacingAidSingleton.Instance.Relative.Entries)
+        {
+            var lapsDriven = driver.LapsDriven;
+            var lapPercentage = lapsDriven - (int)lapsDriven;
 
-    private void UpdateTrackMapPathData(TrackMap trackMap)
-    {
-        TrackMapPathData = TrackMapPathCreator.CreateGeometryGroupFromTrackMap(trackMap, TargetSize);
+            var positionIndexRelativeToLapPercentage = (int)(lapPercentage * nPositions);
+            var position = scaledPositions[positionIndexRelativeToLapPercentage];
+
+            var fillColor = driver.IsLocal ? Brushes.Red : Brushes.LightGray;
+            var borderColor = driver.IsLocal ? Brushes.WhiteSmoke : Brushes.LightGray;   
+            var size = driver.IsLocal ? 20d : 15d;
+            
+            // TODO: update number based on number display type (overall, class, car number)
+            var number = driver.OverallPosition;
+
+            visualizations.Add(new DriverTrackVisualization(position.X, position.Y, size, number, fillColor, borderColor, 2d));
+        }
+        
+        DriverTrackVisualizations = visualizations;
     }
 }


### PR DESCRIPTION
* Added `DriverTrackVisualization` containing all info required in view item control
* Updated `TrackMapOverlay` with ItemControl to programatically create driver visualizations:
  * Ellipse -> visualization of driver on track
  * TextBlock -> number (OverallPosition, ClassPosition, CarNumber; whichever is preferred (will add a config selection option eventually))
* Added logic to update driver visualizations on each update 

One thing to note as a possible reminder:
A canvas item's position is the top left of the item, not the centre - hence the (X - size/2, Y - size/2) implemented in the logic 

closes #11 