### PR TITLE
Fix: Stop track map positions changing on reload

### DIFF
--- a/RacingAidWpf/Core/Tracks/TrackMapUtilities.cs
+++ b/RacingAidWpf/Core/Tracks/TrackMapUtilities.cs
@@ -9,7 +9,8 @@ public static class TrackMapUtilities
         var updatedPositions = new List<TrackMapPosition>();
         foreach (var position in positions)
         {
-            var updatedPosition = position;
+            var updatedPosition = new TrackMapPosition(position.LapDistance, position.X, position.Y, position.Z);
+            
             if (invertY)
                 updatedPosition = InvertYPosition(updatedPosition);
             

--- a/RacingAidWpf/Core/Tracks/TrackMaps.cs
+++ b/RacingAidWpf/Core/Tracks/TrackMaps.cs
@@ -18,4 +18,6 @@ public class TrackMapPosition(float lapDistance, float x, float y, float z)
     public float X { get; set; } = x;
     public float Y { get; set; } = y;
     public float Z { get; set; } = z;
+
+    public override string ToString() => $"Track Pos - Distance: {LapDistance:F2}, Pos: {X:F1}, {Y:F1}, {Z:F1}";
 }

--- a/RacingAidWpf/ViewModel/TrackMapOverlayViewModel.cs
+++ b/RacingAidWpf/ViewModel/TrackMapOverlayViewModel.cs
@@ -160,13 +160,13 @@ public class TrackMapOverlayViewModel : OverlayViewModel
     private static TrackMap TransformTrackMap(TrackMap trackMap)
     {
         // 0.95 for padding
-        trackMap.Positions = TrackMapUtilities.UpdatePositions(
+        var transformedPositions = TrackMapUtilities.UpdatePositions(
             trackMap.Positions,
             true,
             true,
             TargetSize * 0.95f);
-
-        return trackMap;
+        
+        return new TrackMap(trackMap.Name, transformedPositions);
     }
 
     private DriverTrackVisualization CreateDriverTrackVisualization(List<TrackMapPosition> positions, RelativeEntryModel relativeEntryModel, DriverNumberType driverNumberType)


### PR DESCRIPTION
The track map position (class)'s values were being overridden and stored causing the reload to use the 'overridden' values, and further 'overriding' them to infinity.

This fix makes sure a _new_ class is instantiated using the same values. This ensures the original track map positions are untouched.

_Another_ approach would be to load the positions dynamically every load rather than storing it in memory