### PR TITLE
Add Dev tools view & Data recording/replay function

### DIFF
--- a/RacingAid.sln
+++ b/RacingAid.sln
@@ -8,6 +8,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RacingAidWpf", "RacingAidWp
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RacingAidWpfTests", "RacingAidWpfTests\RacingAidWpfTests.csproj", "{6316EA52-76D0-4BB5-BDA5-B47E5BEF0226}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RacingAidGrpc", "RacingAidGrpc\RacingAidGrpc.csproj", "{88328F1F-BBFC-491B-9CBC-0E6CF7219DE2}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -30,5 +32,9 @@ Global
 		{6316EA52-76D0-4BB5-BDA5-B47E5BEF0226}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6316EA52-76D0-4BB5-BDA5-B47E5BEF0226}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6316EA52-76D0-4BB5-BDA5-B47E5BEF0226}.Release|Any CPU.Build.0 = Release|Any CPU
+		{88328F1F-BBFC-491B-9CBC-0E6CF7219DE2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{88328F1F-BBFC-491B-9CBC-0E6CF7219DE2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{88328F1F-BBFC-491B-9CBC-0E6CF7219DE2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{88328F1F-BBFC-491B-9CBC-0E6CF7219DE2}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/RacingAidData/Core/Models/RaceDataModel.cs
+++ b/RacingAidData/Core/Models/RaceDataModel.cs
@@ -2,5 +2,5 @@
 
 public abstract class RaceDataModel
 {
-    public DateTime Timestamp { get; } = DateTime.Now;
+    public DateTime Timestamp { get; set; } = DateTime.Now;
 }

--- a/RacingAidData/Core/Replay/DataRecorder.cs
+++ b/RacingAidData/Core/Replay/DataRecorder.cs
@@ -82,8 +82,9 @@ public class DataRecorder : IRecordData
             return;
 
         await fileWriteSemaphore.WaitAsync();
-
-        var jsonString = JsonConvert.SerializeObject(raceDataRecord);
+        
+        
+        var jsonString = JsonConvert.SerializeObject(raceDataRecord, ReplaySettings.DefaultJsonSerializerSettings);
         await streamWriter.WriteLineAsync(jsonString);
         await streamWriter.FlushAsync();
         

--- a/RacingAidData/Core/Replay/DataRecorder.cs
+++ b/RacingAidData/Core/Replay/DataRecorder.cs
@@ -10,7 +10,6 @@ public class DataRecorder : IRecordData
 {
     private class FileExistsException(string message) : Exception(message);
     
-    
     private const string DefaultFileExtension = ".json1";
     private const string DefaultFileNamePrefix = "RacingAidData";
     private const string DateTimeFormat = "YY-MM-dd_HH-mm-ss";

--- a/RacingAidData/Core/Replay/DataRecorder.cs
+++ b/RacingAidData/Core/Replay/DataRecorder.cs
@@ -1,0 +1,106 @@
+﻿using System.Text;
+using System.Text.Json;
+using RacingAidData.Core.Models;
+
+namespace RacingAidData.Core.Replay;
+
+public class DataRecorder : IRecordData
+{
+    private class FileExistsException(string message) : Exception(message);
+    
+    private const string DateTimeFormat = "YY-MM-dd_HH-mm-ss";
+    private const string DefaultFileNamePrefix = "RacingAidData";
+    
+    private SemaphoreSlim? fileWriteSemaphore;
+    private FileStream? fileStream;
+    
+    private static string DefaultRecordDirectory => Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+        "Recordings");
+    
+    public bool IsRecording { get; private set; }
+    
+    public void Start(string filePath)
+    {
+        if (IsRecording)
+            return;
+        
+        try
+        {
+            filePath = GetFilePath(filePath);
+        }
+        catch (Exception e)
+        {
+            // Raise error but continue
+            Console.WriteLine(e);
+            return;
+        }
+        
+        // Ensures only one write operation at a time
+        fileWriteSemaphore = new SemaphoreSlim(1, 1);
+        
+        OpenRecordingFile(filePath);
+        IsRecording = true;
+    }
+
+    public async Task StopAsync()
+    {
+        if (!IsRecording)
+            return;
+        
+        await CloseRecordingFileAsync();
+        IsRecording = false;
+    }
+
+    private async Task CloseRecordingFileAsync()
+    {
+        if (fileStream == null || fileWriteSemaphore == null)
+            return;
+        
+        await fileStream.FlushAsync();
+        await fileStream.DisposeAsync();
+        fileStream = null;
+        
+        fileWriteSemaphore?.Dispose();
+        fileWriteSemaphore = null;
+    }
+
+    public async Task AddRecordAsync(RaceDataModel raceDataRecord)
+    {
+        if (fileStream == null || fileWriteSemaphore == null)
+            return;
+
+        await fileWriteSemaphore.WaitAsync();
+
+        var bytes = ModelToBytes(raceDataRecord);
+        
+        await fileStream.WriteAsync(bytes);
+        await fileStream.FlushAsync();
+        
+        fileWriteSemaphore.Release();
+    }
+
+    private void OpenRecordingFile(string filePath)
+    {
+        fileStream = new FileStream(filePath, FileMode.Append, FileAccess.Write, FileShare.Read);
+    }
+
+    private static string GetFilePath(string filePath)
+    {
+        if (string.IsNullOrEmpty(filePath))
+            filePath = Path.Combine(DefaultRecordDirectory, DefaultFileNamePrefix);
+        
+        filePath += $"_{DateTime.Now.ToString(DateTimeFormat)}";
+
+        if (File.Exists(filePath))
+            throw new FileExistsException("File already exists");
+        
+        return filePath;
+    }
+
+    private static byte[] ModelToBytes(RaceDataModel raceDataRecord)
+    {
+        var json = JsonSerializer.Serialize(raceDataRecord);
+        return Encoding.UTF8.GetBytes(json + Environment.NewLine);
+    }
+}

--- a/RacingAidData/Core/Replay/DataRecorder.cs
+++ b/RacingAidData/Core/Replay/DataRecorder.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text.Json;
+using Newtonsoft.Json;
 using RacingAidData.Core.Models;
 
 namespace RacingAidData.Core.Replay;
@@ -82,7 +83,7 @@ public class DataRecorder : IRecordData
 
         await fileWriteSemaphore.WaitAsync();
 
-        var jsonString = JsonSerializer.Serialize(raceDataRecord);
+        var jsonString = JsonConvert.SerializeObject(raceDataRecord);
         await streamWriter.WriteLineAsync(jsonString);
         await streamWriter.FlushAsync();
         

--- a/RacingAidData/Core/Replay/DataRecorder.cs
+++ b/RacingAidData/Core/Replay/DataRecorder.cs
@@ -10,10 +10,10 @@ public class DataRecorder : IRecordData
 {
     private class FileExistsException(string message) : Exception(message);
     
-    private const string FileExtension = ".json1";
     
-    private const string DateTimeFormat = "YY-MM-dd_HH-mm-ss";
+    private const string DefaultFileExtension = ".json1";
     private const string DefaultFileNamePrefix = "RacingAidData";
+    private const string DateTimeFormat = "YY-MM-dd_HH-mm-ss";
     
     private SemaphoreSlim? fileWriteSemaphore;
     private StreamWriter? streamWriter;
@@ -23,8 +23,11 @@ public class DataRecorder : IRecordData
         "Recordings");
     
     public bool IsRecording { get; private set; }
+
+    public string RecordDirectory => DefaultRecordDirectory;
+    public string RecordExtension => DefaultFileExtension;
     
-    public void Start(string directory, string fileName)
+    public void Start(string fileName)
     {
         if (IsRecording)
             return;
@@ -33,7 +36,7 @@ public class DataRecorder : IRecordData
         
         try
         {
-            filePath = GetFilePath(directory, fileName);
+            filePath = GetFilePath(fileName);
         }
         catch (Exception e)
         {
@@ -90,14 +93,13 @@ public class DataRecorder : IRecordData
         streamWriter = new StreamWriter(filePath);
     }
 
-    private static string GetFilePath(string directory, string fileName)
+    private string GetFilePath(string fileName)
     {
-        var filePath = Path.Combine(directory, fileName);
-        
-        if (string.IsNullOrEmpty(filePath))
-            filePath = Path.Combine(DefaultRecordDirectory, DefaultFileNamePrefix);
-        
-        filePath += $"_{DateTime.Now.ToString(DateTimeFormat)}{FileExtension}";
+        if (string.IsNullOrEmpty(fileName))
+            fileName = $"{DefaultFileNamePrefix}_{DateTime.Now.ToString(DateTimeFormat)}";
+
+        fileName = Path.ChangeExtension(fileName, RecordExtension);
+        var filePath = Path.Combine(RecordDirectory, fileName);
 
         if (File.Exists(filePath))
             throw new FileExistsException("File already exists");

--- a/RacingAidData/Core/Replay/DataReplayer.cs
+++ b/RacingAidData/Core/Replay/DataReplayer.cs
@@ -108,16 +108,12 @@ public class DataReplayer : IReplayData
     private bool DelayTillNextPacketSend(TimeSpan timestampDelta, TimeSpan timeSinceLastDataUpdate)
     {
         var dataDelay = timestampDelta.Subtract(timeSinceLastDataUpdate);
+        Console.WriteLine($"delay: {dataDelay}");
 
-        try
-        {
-            Task.Delay(dataDelay, cancellationToken);
-        }
-        catch (OperationCanceledException)
-        {
+        if (dataDelay < TimeSpan.Zero)
             return false;
-        }
-
+        
+        Thread.Sleep(dataDelay);
         return true;
     }
 }

--- a/RacingAidData/Core/Replay/DataReplayer.cs
+++ b/RacingAidData/Core/Replay/DataReplayer.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json;
+﻿using Newtonsoft.Json;
 using RacingAidData.Core.Models;
 
 namespace RacingAidData.Core.Replay;
@@ -59,6 +59,9 @@ public class DataReplayer : IReplayData
         
         // Handle the first object outside the loop to get the start time
         // We use the timestamp so that we know when to send the next bit of data
+        if (!replayDataEnumerator.MoveNext())
+            return;
+        
         var firstData = replayDataEnumerator.Current;
         var previousPacketTimestamp = firstData.Timestamp;
 
@@ -94,7 +97,7 @@ public class DataReplayer : IReplayData
             if (string.IsNullOrWhiteSpace(line))
                 continue; 
             
-            if (JsonSerializer.Deserialize<RaceDataModel>(line) is { } data)
+            if (JsonConvert.DeserializeObject<RaceDataModel>(line, ReplaySettings.DefaultJsonSerializerSettings) is { } data)
                 yield return data;
         }
     }

--- a/RacingAidData/Core/Replay/DataReplayer.cs
+++ b/RacingAidData/Core/Replay/DataReplayer.cs
@@ -1,0 +1,120 @@
+﻿using System.Text.Json;
+using RacingAidData.Core.Models;
+
+namespace RacingAidData.Core.Replay;
+
+/// <summary>
+/// Replay racing data stored in a newline-delimited json (.json1) file format
+/// </summary>
+public class DataReplayer : IReplayData
+{
+    private string replayFilePath = string.Empty;
+    private Thread? replayThread;
+    private CancellationTokenSource? cancellationTokenSource;
+    private CancellationToken cancellationToken;
+
+    public event Action<RaceDataModel>? RaceDataReceived;
+    
+    public bool IsSetup => !string.IsNullOrEmpty(replayFilePath);
+    public bool IsReplaying => replayThread is { IsAlive: true };
+
+    public void SetupReplay(string filePath)
+    {
+        if (string.IsNullOrEmpty(filePath) || !File.Exists(filePath))
+            return;
+
+        replayFilePath = filePath;
+    }
+
+    public void Start()
+    {
+        if (!IsSetup || IsReplaying)
+            return;
+
+        replayThread = new Thread(ReplayLoop);
+        replayThread.Start();
+    }
+
+    public void Stop()
+    {
+        if (!IsReplaying)
+            return;
+        
+        cancellationTokenSource?.Cancel();
+        
+        replayThread?.Join();
+        cancellationTokenSource = null;
+        replayThread = null;
+    }
+
+    private void ReplayLoop()
+    {
+        if (cancellationTokenSource == null)
+        {
+            cancellationTokenSource = new CancellationTokenSource();
+            cancellationToken = cancellationTokenSource.Token;
+        }
+        
+        using var replayDataEnumerator = ReadObjectsFromFile(replayFilePath).GetEnumerator();
+        
+        // Handle the first object outside the loop to get the start time
+        // We use the timestamp so that we know when to send the next bit of data
+        var firstData = replayDataEnumerator.Current;
+        var previousPacketTimestamp = firstData.Timestamp;
+
+        RaceDataReceived?.Invoke(firstData);
+        var timeOfLastDataUpdate = DateTime.Now;
+
+        while (!cancellationToken.IsCancellationRequested && replayDataEnumerator.MoveNext())
+        {
+            var currentData = replayDataEnumerator.Current;
+            var currentDataTimestamp = currentData.Timestamp;
+
+            var timestampDelta = currentDataTimestamp - previousPacketTimestamp;
+            var timeSinceLastDataUpdate = DateTime.Now - timeOfLastDataUpdate;
+
+            // If delay was not successfully completed, check if cancellation was requested
+            var delaySuccess = DelayTillNextPacketSend(timestampDelta, timeSinceLastDataUpdate);
+            if (!delaySuccess && cancellationToken.IsCancellationRequested)
+                break;
+            
+            RaceDataReceived?.Invoke(currentData);
+            previousPacketTimestamp = currentDataTimestamp;
+            timeOfLastDataUpdate = DateTime.Now;
+        }
+    }
+
+    private static IEnumerable<RaceDataModel> ReadObjectsFromFile(string filePath)
+    {
+        using var sr = new StreamReader(filePath);
+
+        while (sr.ReadLine() is { } line)
+        {
+            // Ignore empty lines
+            if (string.IsNullOrWhiteSpace(line))
+                continue; 
+            
+            if (JsonSerializer.Deserialize<RaceDataModel>(line) is { } data)
+                yield return data;
+        }
+    }
+
+    /// <summary>
+    /// Let's use the bool as a way to determine if the delay was successfully completed
+    /// </summary>
+    private bool DelayTillNextPacketSend(TimeSpan timestampDelta, TimeSpan timeSinceLastDataUpdate)
+    {
+        var dataDelay = timestampDelta.Subtract(timeSinceLastDataUpdate);
+
+        try
+        {
+            Task.Delay(dataDelay, cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/RacingAidData/Core/Replay/DataReplayer.cs
+++ b/RacingAidData/Core/Replay/DataReplayer.cs
@@ -13,7 +13,7 @@ public class DataReplayer : IReplayData
     private CancellationTokenSource? cancellationTokenSource;
     private CancellationToken cancellationToken;
 
-    public event Action<RaceDataModel>? RaceDataReceived;
+    public event Action<RaceDataModel>? ReplayDataReceived;
     
     public bool IsSetup => !string.IsNullOrEmpty(replayFilePath);
     public bool IsReplaying => replayThread is { IsAlive: true };
@@ -62,7 +62,7 @@ public class DataReplayer : IReplayData
         var firstData = replayDataEnumerator.Current;
         var previousPacketTimestamp = firstData.Timestamp;
 
-        RaceDataReceived?.Invoke(firstData);
+        ReplayDataReceived?.Invoke(firstData);
         var timeOfLastDataUpdate = DateTime.Now;
 
         while (!cancellationToken.IsCancellationRequested && replayDataEnumerator.MoveNext())
@@ -78,9 +78,9 @@ public class DataReplayer : IReplayData
             if (!delaySuccess && cancellationToken.IsCancellationRequested)
                 break;
             
-            RaceDataReceived?.Invoke(currentData);
-            previousPacketTimestamp = currentDataTimestamp;
+            ReplayDataReceived?.Invoke(currentData);
             timeOfLastDataUpdate = DateTime.Now;
+            previousPacketTimestamp = currentDataTimestamp;
         }
     }
 

--- a/RacingAidData/Core/Replay/IRecordData.cs
+++ b/RacingAidData/Core/Replay/IRecordData.cs
@@ -10,7 +10,6 @@ public interface IRecordData
     public string RecordExtension { get; }
     
     public string Start(string fileName);
-    public Task StopAsync();
-    
-    public Task AddRecordAsync(RaceDataModel raceDataRecord);
+    public void Stop();
+    public void AddRecord(RaceDataModel raceData);
 }

--- a/RacingAidData/Core/Replay/IRecordData.cs
+++ b/RacingAidData/Core/Replay/IRecordData.cs
@@ -9,7 +9,7 @@ public interface IRecordData
     public string RecordDirectory { get; }
     public string RecordExtension { get; }
     
-    public void Start(string fileName);
+    public string Start(string fileName);
     public Task StopAsync();
     
     public Task AddRecordAsync(RaceDataModel raceDataRecord);

--- a/RacingAidData/Core/Replay/IRecordData.cs
+++ b/RacingAidData/Core/Replay/IRecordData.cs
@@ -1,0 +1,13 @@
+﻿using RacingAidData.Core.Models;
+
+namespace RacingAidData.Core.Replay;
+
+public interface IRecordData
+{
+    public bool IsRecording { get; }
+    
+    public void Start(string filePath);
+    public Task StopAsync();
+    
+    public Task AddRecordAsync(RaceDataModel raceDataRecord);
+}

--- a/RacingAidData/Core/Replay/IRecordData.cs
+++ b/RacingAidData/Core/Replay/IRecordData.cs
@@ -6,7 +6,7 @@ public interface IRecordData
 {
     public bool IsRecording { get; }
     
-    public void Start(string filePath);
+    public void Start(string directory, string filename);
     public Task StopAsync();
     
     public Task AddRecordAsync(RaceDataModel raceDataRecord);

--- a/RacingAidData/Core/Replay/IRecordData.cs
+++ b/RacingAidData/Core/Replay/IRecordData.cs
@@ -6,7 +6,10 @@ public interface IRecordData
 {
     public bool IsRecording { get; }
     
-    public void Start(string directory, string filename);
+    public string RecordDirectory { get; }
+    public string RecordExtension { get; }
+    
+    public void Start(string fileName);
     public Task StopAsync();
     
     public Task AddRecordAsync(RaceDataModel raceDataRecord);

--- a/RacingAidData/Core/Replay/IReplayControl.cs
+++ b/RacingAidData/Core/Replay/IReplayControl.cs
@@ -10,11 +10,11 @@ public interface IReplayControl
     public bool IsReplaying { get; }
     
     public void StartRecording(string filePath);
-    public void RecordDataAsync(RaceDataModel data);
+    public void RecordData(RaceDataModel data);
     public Task StopRecordingAsync();
 
     public IList<string> GetReplays();
-    public void SelectReplay(string filePath);
+    public bool SelectReplay(string filePath);
     public void StartReplay();
     public void StopReplay();
 }

--- a/RacingAidData/Core/Replay/IReplayControl.cs
+++ b/RacingAidData/Core/Replay/IReplayControl.cs
@@ -5,6 +5,7 @@ namespace RacingAidData.Core.Replay;
 public interface IReplayControl
 {
     public event Action<RaceDataModel> ReplayDataReceived;
+    public event Action<bool> IsReplayingUpdated;
     
     public bool IsRecording { get; }
     public bool IsReplaying { get; }

--- a/RacingAidData/Core/Replay/IReplayControl.cs
+++ b/RacingAidData/Core/Replay/IReplayControl.cs
@@ -1,0 +1,20 @@
+﻿using RacingAidData.Core.Models;
+
+namespace RacingAidData.Core.Replay;
+
+public interface IReplayControl
+{
+    public event Action<RaceDataModel> ReplayDataReceived;
+    
+    public bool IsRecording { get; }
+    public bool IsReplaying { get; }
+    
+    public void StartRecording(string filePath);
+    public void RecordDataAsync(RaceDataModel data);
+    public Task StopRecordingAsync();
+
+    public IList<string> GetReplays();
+    public void SelectReplay(string filePath);
+    public void StartReplay();
+    public void StopReplay();
+}

--- a/RacingAidData/Core/Replay/IReplayControl.cs
+++ b/RacingAidData/Core/Replay/IReplayControl.cs
@@ -9,9 +9,9 @@ public interface IReplayControl
     public bool IsRecording { get; }
     public bool IsReplaying { get; }
     
-    public void StartRecording(string filePath);
+    public string StartRecording(string filePath);
     public void RecordData(RaceDataModel data);
-    public Task StopRecordingAsync();
+    public void StopRecording();
 
     public IList<string> GetReplays();
     public bool SelectReplay(string filePath);

--- a/RacingAidData/Core/Replay/IReplayControl.cs
+++ b/RacingAidData/Core/Replay/IReplayControl.cs
@@ -10,6 +10,8 @@ public interface IReplayControl
     public bool IsRecording { get; }
     public bool IsReplaying { get; }
     
+    public ReplaySpeed ReplaySpeed { set; }
+    
     public string StartRecording(string filePath);
     public void RecordData(RaceDataModel data);
     public void StopRecording();

--- a/RacingAidData/Core/Replay/IReplayData.cs
+++ b/RacingAidData/Core/Replay/IReplayData.cs
@@ -5,6 +5,8 @@ namespace RacingAidData.Core.Replay;
 public interface IReplayData
 {
     public event Action<RaceDataModel> ReplayDataReceived;
+    
+    public ReplaySpeed ReplaySpeed { set; }
     public bool IsSetup { get; }
     public bool IsReplaying { get; }
 

--- a/RacingAidData/Core/Replay/IReplayData.cs
+++ b/RacingAidData/Core/Replay/IReplayData.cs
@@ -1,0 +1,12 @@
+﻿namespace RacingAidData.Core.Replay;
+
+public interface IReplayData
+{
+    public bool IsSetup { get; }
+    public bool IsReplaying { get; }
+
+    public void SetupReplay(string filePath);
+    
+    public void Start();
+    public void Stop();
+}

--- a/RacingAidData/Core/Replay/IReplayData.cs
+++ b/RacingAidData/Core/Replay/IReplayData.cs
@@ -1,7 +1,10 @@
-﻿namespace RacingAidData.Core.Replay;
+﻿using RacingAidData.Core.Models;
+
+namespace RacingAidData.Core.Replay;
 
 public interface IReplayData
 {
+    public event Action<RaceDataModel> ReplayDataReceived;
     public bool IsSetup { get; }
     public bool IsReplaying { get; }
 

--- a/RacingAidData/Core/Replay/NewLineDelimitedJsonFileWriter.cs
+++ b/RacingAidData/Core/Replay/NewLineDelimitedJsonFileWriter.cs
@@ -1,0 +1,62 @@
+﻿using System.Collections.Concurrent;
+using Newtonsoft.Json;
+
+namespace RacingAidData.Core.Replay;
+
+public class NewLineDelimitedJsonFileWriter<T> : IDisposable where T : class
+{
+    private const int QueueSizeWarningValue = 5;
+    
+    private readonly BlockingCollection<T> dataQueue = new();
+    private readonly string filePath;
+    private readonly Thread writerThread;
+    private bool isActive;
+
+    public NewLineDelimitedJsonFileWriter(string filePath)
+    {
+        this.filePath = filePath;
+        writerThread = new Thread(WriteLoop)
+        {
+            IsBackground = true, // Allows the application to exit even if this thread is running
+            Name = "NewLineDelimitedJsonFileWriter"
+        };
+        writerThread.Start();
+        isActive = true;
+    }
+
+    public void EnqueueData(T data)
+    {
+        if (isActive)
+            dataQueue.Add(data);
+    }
+
+    public void Dispose()
+    {
+        if (!isActive)
+            return;
+
+        isActive = false;
+        dataQueue.CompleteAdding();
+        writerThread.Join();
+        dataQueue.Dispose();
+        
+        GC.SuppressFinalize(this);
+    }
+
+    private void WriteLoop()
+    {
+        using var writer = new StreamWriter(filePath);
+        
+        // Blocks until an item is available or CompleteAdding is called
+        foreach (var dataItem in dataQueue.GetConsumingEnumerable())
+        {
+            var queueCount = dataQueue.Count;
+            if (queueCount >= QueueSizeWarningValue)
+                Console.WriteLine($"Queue is getting large -> items: {queueCount}");
+
+            var json = JsonConvert.SerializeObject(dataItem, ReplaySettings.DefaultJsonSerializerSettings);
+            writer.WriteLine(json);
+            writer.Flush();
+        }
+    }
+}

--- a/RacingAidData/Core/Replay/ReplayController.cs
+++ b/RacingAidData/Core/Replay/ReplayController.cs
@@ -1,0 +1,61 @@
+﻿namespace RacingAidData.Core.Replay;
+
+public class ReplayController
+{
+    private readonly IRecordData dataRecorder;
+    private readonly IReplayData dataReplayer;
+    
+    public bool IsRecording => dataRecorder.IsRecording;
+    public bool IsReplaying => dataReplayer.IsReplaying;
+
+    public ReplayController(IRecordData? dataRecorder = null, IReplayData? dataReplayer = null)
+    {
+        this.dataRecorder = dataRecorder ?? new DataRecorder();
+        this.dataReplayer = dataReplayer ?? new DataReplayer();
+    }
+
+    public void StartRecording(string filePath = "")
+    {
+        if (IsRecording || IsReplaying)
+            return;
+        
+        var directory = Path.GetDirectoryName(filePath) ?? string.Empty;
+        var fileName = Path.GetFileNameWithoutExtension(filePath);
+        
+        dataRecorder.Start(directory, fileName);
+    }
+
+    public async Task StopRecordingAsync()
+    {
+        if (!IsRecording || IsReplaying)
+            return;
+        
+        await dataRecorder.StopAsync();
+    }
+
+    public IList<string> GetReplays()
+    {
+        return new List<string>();
+    }
+
+    public void SelectReplay(string filePath)
+    {
+        dataReplayer.SetupReplay(filePath);
+    }
+
+    public void StartReplay()
+    {
+        if (IsRecording || IsReplaying)
+            return;
+        
+        dataReplayer.Start();
+    }
+
+    public void StopReplay()
+    {
+        if (IsRecording || !IsReplaying)
+            return;
+        
+        dataReplayer.Stop();
+    }
+}

--- a/RacingAidData/Core/Replay/ReplayController.cs
+++ b/RacingAidData/Core/Replay/ReplayController.cs
@@ -19,12 +19,12 @@ public class ReplayController : IReplayControl
         this.dataReplayer.ReplayDataReceived += model => { ReplayDataReceived?.Invoke(model); };
     }
 
-    public void StartRecording(string fileName = "")
+    public string StartRecording(string fileName = "")
     {
         if (IsRecording || IsReplaying)
-            return;
+            return string.Empty;
         
-        dataRecorder.Start(fileName);
+        return dataRecorder.Start(fileName);
     }
 
     public void RecordData(RaceDataModel data)
@@ -32,12 +32,12 @@ public class ReplayController : IReplayControl
         Task.Run(async () => await dataRecorder.AddRecordAsync(data));
     }
 
-    public async Task StopRecordingAsync()
+    public void StopRecording()
     {
         if (!IsRecording || IsReplaying)
             return;
         
-        await dataRecorder.StopAsync();
+        Task.Run(async () => await dataRecorder.StopAsync());
     }
 
     public IList<string> GetReplays()

--- a/RacingAidData/Core/Replay/ReplayController.cs
+++ b/RacingAidData/Core/Replay/ReplayController.cs
@@ -12,6 +12,11 @@ public class ReplayController : IReplayControl
     public bool IsRecording => dataRecorder.IsRecording;
     public bool IsReplaying => dataReplayer.IsReplaying;
 
+    public ReplaySpeed ReplaySpeed
+    {
+        set => dataReplayer.ReplaySpeed = value;
+    }
+
     public ReplayController(IRecordData? dataRecorder = null, IReplayData? dataReplayer = null)
     {
         this.dataRecorder = dataRecorder ?? new DataRecorder();

--- a/RacingAidData/Core/Replay/ReplayController.cs
+++ b/RacingAidData/Core/Replay/ReplayController.cs
@@ -14,15 +14,12 @@ public class ReplayController
         this.dataReplayer = dataReplayer ?? new DataReplayer();
     }
 
-    public void StartRecording(string filePath = "")
+    public void StartRecording(string fileName = "")
     {
         if (IsRecording || IsReplaying)
             return;
         
-        var directory = Path.GetDirectoryName(filePath) ?? string.Empty;
-        var fileName = Path.GetFileNameWithoutExtension(filePath);
-        
-        dataRecorder.Start(directory, fileName);
+        dataRecorder.Start(fileName);
     }
 
     public async Task StopRecordingAsync()
@@ -35,17 +32,22 @@ public class ReplayController
 
     public IList<string> GetReplays()
     {
-        return new List<string>();
+        return Directory.GetFiles(dataRecorder.RecordDirectory, $"*{dataRecorder.RecordExtension}");
     }
 
-    public void SelectReplay(string filePath)
+    public bool SelectReplay(string filePath)
     {
+        if (!GetReplays().Contains(filePath))
+            return false;
+        
         dataReplayer.SetupReplay(filePath);
+        return true;
+
     }
 
     public void StartReplay()
     {
-        if (IsRecording || IsReplaying)
+        if (IsRecording || IsReplaying || !dataReplayer.IsSetup)
             return;
         
         dataReplayer.Start();

--- a/RacingAidData/Core/Replay/ReplayController.cs
+++ b/RacingAidData/Core/Replay/ReplayController.cs
@@ -1,10 +1,13 @@
-﻿namespace RacingAidData.Core.Replay;
+﻿using RacingAidData.Core.Models;
 
-public class ReplayController
+namespace RacingAidData.Core.Replay;
+
+public class ReplayController : IReplayControl
 {
     private readonly IRecordData dataRecorder;
     private readonly IReplayData dataReplayer;
-    
+
+    public event Action<RaceDataModel>? ReplayDataReceived;
     public bool IsRecording => dataRecorder.IsRecording;
     public bool IsReplaying => dataReplayer.IsReplaying;
 
@@ -12,6 +15,8 @@ public class ReplayController
     {
         this.dataRecorder = dataRecorder ?? new DataRecorder();
         this.dataReplayer = dataReplayer ?? new DataReplayer();
+
+        this.dataReplayer.ReplayDataReceived += model => { ReplayDataReceived?.Invoke(model); };
     }
 
     public void StartRecording(string fileName = "")
@@ -20,6 +25,11 @@ public class ReplayController
             return;
         
         dataRecorder.Start(fileName);
+    }
+
+    public void RecordData(RaceDataModel data)
+    {
+        Task.Run(async () => await dataRecorder.AddRecordAsync(data));
     }
 
     public async Task StopRecordingAsync()

--- a/RacingAidData/Core/Replay/ReplayController.cs
+++ b/RacingAidData/Core/Replay/ReplayController.cs
@@ -8,6 +8,7 @@ public class ReplayController : IReplayControl
     private readonly IReplayData dataReplayer;
 
     public event Action<RaceDataModel>? ReplayDataReceived;
+    public event Action<bool>? IsReplayingUpdated;
     public bool IsRecording => dataRecorder.IsRecording;
     public bool IsReplaying => dataReplayer.IsReplaying;
 
@@ -29,7 +30,7 @@ public class ReplayController : IReplayControl
 
     public void RecordData(RaceDataModel data)
     {
-        Task.Run(async () => await dataRecorder.AddRecordAsync(data));
+        dataRecorder.AddRecord(data);
     }
 
     public void StopRecording()
@@ -37,7 +38,7 @@ public class ReplayController : IReplayControl
         if (!IsRecording || IsReplaying)
             return;
         
-        Task.Run(async () => await dataRecorder.StopAsync());
+        dataRecorder.Stop();
     }
 
     public IList<string> GetReplays()
@@ -59,8 +60,9 @@ public class ReplayController : IReplayControl
     {
         if (IsRecording || IsReplaying || !dataReplayer.IsSetup)
             return;
-        
+
         dataReplayer.Start();
+        IsReplayingUpdated?.Invoke(IsReplaying);
     }
 
     public void StopReplay()
@@ -69,5 +71,6 @@ public class ReplayController : IReplayControl
             return;
         
         dataReplayer.Stop();
+        IsReplayingUpdated?.Invoke(IsReplaying);
     }
 }

--- a/RacingAidData/Core/Replay/ReplaySettings.cs
+++ b/RacingAidData/Core/Replay/ReplaySettings.cs
@@ -1,0 +1,11 @@
+﻿using Newtonsoft.Json;
+
+namespace RacingAidData.Core.Replay;
+
+public static class ReplaySettings
+{
+    public static JsonSerializerSettings DefaultJsonSerializerSettings = new()
+    {
+        TypeNameHandling = TypeNameHandling.All
+    };
+}

--- a/RacingAidData/Core/Replay/ReplaySettings.cs
+++ b/RacingAidData/Core/Replay/ReplaySettings.cs
@@ -4,7 +4,7 @@ namespace RacingAidData.Core.Replay;
 
 public static class ReplaySettings
 {
-    public static JsonSerializerSettings DefaultJsonSerializerSettings = new()
+    public static readonly JsonSerializerSettings DefaultJsonSerializerSettings = new()
     {
         TypeNameHandling = TypeNameHandling.All
     };

--- a/RacingAidData/Core/Replay/ReplaySpeed.cs
+++ b/RacingAidData/Core/Replay/ReplaySpeed.cs
@@ -1,0 +1,21 @@
+﻿using System.ComponentModel;
+
+namespace RacingAidData.Core.Replay;
+
+public enum ReplaySpeed
+{
+    [Description("Normal")]
+    X1,
+    
+    [Description("2x")]
+    X2,
+    
+    [Description("4x")]
+    X4,
+    
+    [Description("8x")]
+    X8,
+    
+    [Description("16x")]
+    X16
+}

--- a/RacingAidData/RacingAid.cs
+++ b/RacingAidData/RacingAid.cs
@@ -2,6 +2,7 @@
 using RacingAidData.Core.Models;
 using RacingAidData.Core.Subscribers;
 using RacingAidData.Simulators;
+using RacingAidData.Simulators.Debug;
 using RacingAidData.Simulators.iRacing;
 
 namespace RacingAidData;
@@ -132,6 +133,10 @@ public class RacingAid
             case Simulator.iRacing:
                 DataDeserializer = new iRacingDataDeserializer();
                 DataSubscriber = new iRacingDataSubscriber();
+                break;
+            case Simulator.Debug:
+                DataDeserializer = new DebugDeserializer();
+                DataSubscriber = new DebugSubscriber();
                 break;
             default:
                 throw new ArgumentOutOfRangeException(nameof(simulator), simulator, null);

--- a/RacingAidData/RacingAid.cs
+++ b/RacingAidData/RacingAid.cs
@@ -196,7 +196,7 @@ public class RacingAid
             UpdateModel(model);
 
             if (replayController is { IsRecording: true } recorder)
-                recorder.RecordDataAsync(model);
+                recorder.RecordData(model);
         }
         
         MaybeTriggerModelUpdate();

--- a/RacingAidData/RacingAid.cs
+++ b/RacingAidData/RacingAid.cs
@@ -1,5 +1,6 @@
 ﻿using RacingAidData.Core.Deserializers;
 using RacingAidData.Core.Models;
+using RacingAidData.Core.Replay;
 using RacingAidData.Core.Subscribers;
 using RacingAidData.Simulators;
 using RacingAidData.Simulators.Debug;
@@ -9,6 +10,8 @@ namespace RacingAidData;
 
 public class RacingAid
 {
+    private IReplayControl? replayController;
+    
     private bool modelsHaveUpdated;
     private bool isRunning;
     
@@ -34,9 +37,9 @@ public class RacingAid
         }
     }
 
-    public event Action<bool> InSessionUpdated;
+    public event Action<bool>? InSessionUpdated;
 
-    public event Action ModelsUpdated;
+    public event Action? ModelsUpdated;
     
     #region Model Properties
 
@@ -119,9 +122,19 @@ public class RacingAid
 
     public bool InSession => DataSubscriber is { IsConnected: true };
 
-    public RacingAid()
+    public RacingAid(IReplayControl? replayControl = null)
     {
+        if (replayControl != null)
+            SetupReplayController(replayControl);
+        
         SetupSimulator(Simulator.iRacing);
+    }
+
+    public void SetupReplayController(IReplayControl replayControl)
+    {
+        replayController = replayControl;
+
+        replayController.ReplayDataReceived += OnReplayDataReceived;
     }
 
     public void SetupSimulator(Simulator simulator)
@@ -179,8 +192,24 @@ public class RacingAid
             return;
 
         foreach (var model in models)
+        {
             UpdateModel(model);
 
+            if (replayController is { IsRecording: true } recorder)
+                recorder.RecordDataAsync(model);
+        }
+        
+        MaybeTriggerModelUpdate();
+    }
+
+    private void OnReplayDataReceived(RaceDataModel model)
+    {
+        UpdateModel(model);
+        MaybeTriggerModelUpdate();
+    }
+
+    private void MaybeTriggerModelUpdate()
+    {
         if (modelsHaveUpdated)
             ModelsUpdated?.Invoke();
         

--- a/RacingAidData/RacingAidData.csproj
+++ b/RacingAidData/RacingAidData.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+        <TargetFramework>net8.0-windows</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/RacingAidData/RacingAidData.csproj
+++ b/RacingAidData/RacingAidData.csproj
@@ -10,4 +10,8 @@
       <PackageReference Include="IRSDKSharper" Version="1.1.3" />
     </ItemGroup>
 
+    <ItemGroup>
+      <ProjectReference Include="..\RacingAidGrpc\RacingAidGrpc.csproj" />
+    </ItemGroup>
+
 </Project>

--- a/RacingAidData/RacingAidData.csproj
+++ b/RacingAidData/RacingAidData.csproj
@@ -8,6 +8,7 @@
 
     <ItemGroup>
       <PackageReference Include="IRSDKSharper" Version="1.1.3" />
+      <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     </ItemGroup>
 
     <ItemGroup>

--- a/RacingAidData/Simulators/Debug/DebugDeserializer.cs
+++ b/RacingAidData/Simulators/Debug/DebugDeserializer.cs
@@ -1,0 +1,35 @@
+﻿using IRSDKSharper;
+using RacingAidData.Core.Deserializers;
+using RacingAidData.Core.Models;
+
+namespace RacingAidData.Simulators.Debug;
+
+public class DebugDeserializer : IDeserializeData
+{
+    public bool TryDeserializeData(object data, out List<RaceDataModel> models)
+    {
+        models = [];
+        
+        return models.Count > 0;
+    }
+
+    private static List<LeaderboardEntryModel> CreateTimesheetEntries(IRacingSdkData iRacingData)
+    {
+        return [];
+    }
+
+    private static List<RelativeEntryModel> CreateRelativeEntries(IRacingSdkData iRacingData)
+    {
+        return [];
+    }
+
+    private static RaceDataModel CreateTelemetryModel(IRacingSdkData iRacingData)
+    {
+        return new TelemetryModel();
+    }
+
+    private static DriverDataModel CreateDriverModel(IRacingSdkData iRacingData)
+    {
+        return new DriverDataModel();
+    }
+}

--- a/RacingAidData/Simulators/Debug/DebugSubscriber.cs
+++ b/RacingAidData/Simulators/Debug/DebugSubscriber.cs
@@ -1,0 +1,36 @@
+﻿using RacingAidData.Core.Subscribers;
+using RacingAidGrpc;
+
+namespace RacingAidData.Simulators.Debug;
+
+public class DebugSubscriber : ISubscribeData
+{
+    private readonly TelemetryClient telemetryClient;
+    
+    public event Action? DataReceived;
+    public event Action<bool>? ConnectionUpdated;
+    public object? LatestData { get; private set; }
+    public bool IsConnected => telemetryClient.IsConnected;
+    public bool IsSubscribed => telemetryClient.IsStarted;
+
+    public DebugSubscriber()
+    {
+        telemetryClient = new TelemetryClient();
+        telemetryClient.SessionStatusUpdated += OnStatusUpdated;
+    }
+
+    private void OnStatusUpdated(object? sender, bool status)
+    {
+        ConnectionUpdated?.Invoke(status);
+    }
+
+    public void Start()
+    {
+        telemetryClient.Start();
+    }
+
+    public void Stop()
+    {
+        telemetryClient.Stop();
+    }
+}

--- a/RacingAidData/Simulators/Simulator.cs
+++ b/RacingAidData/Simulators/Simulator.cs
@@ -9,7 +9,4 @@ public enum Simulator
     
     [Description("Formula 1")]
     F1,
-    
-    [Description("Debug")]
-    Debug
 }

--- a/RacingAidData/Simulators/Simulator.cs
+++ b/RacingAidData/Simulators/Simulator.cs
@@ -8,5 +8,8 @@ public enum Simulator
     iRacing,
     
     [Description("Formula 1")]
-    F1
+    F1,
+    
+    [Description("Debug")]
+    Debug
 }

--- a/RacingAidData/Simulators/iRacing/iRacingDataSubscriber.cs
+++ b/RacingAidData/Simulators/iRacing/iRacingDataSubscriber.cs
@@ -26,16 +26,6 @@ public class iRacingDataSubscriber : ISubscribeData
         iRacingSdk.OnDisconnected += OnDisconnected;
     }
 
-    private void OnConnected()
-    {
-        ConnectionUpdated?.Invoke(IsConnected);
-    }
-
-    private void OnDisconnected()
-    {
-        ConnectionUpdated?.Invoke(IsConnected);
-    }
-
     public void Start()
     {
         iRacingSdk.Start();
@@ -50,5 +40,15 @@ public class iRacingDataSubscriber : ISubscribeData
     {
         LatestData = iRacingSdk.Data;
         DataReceived?.Invoke();
+    }
+
+    private void OnConnected()
+    {
+        ConnectionUpdated?.Invoke(IsConnected);
+    }
+
+    private void OnDisconnected()
+    {
+        ConnectionUpdated?.Invoke(IsConnected);
     }
 }

--- a/RacingAidGrpc/Protos/telemetry.proto
+++ b/RacingAidGrpc/Protos/telemetry.proto
@@ -1,0 +1,13 @@
+﻿syntax = "proto3";
+
+option csharp_namespace = "RacingAidGrpc";
+
+import "google/protobuf/empty.proto";
+
+service Telemetry {
+  rpc SubscribeToSessionStatus (google.protobuf.Empty) returns (stream SessionStatusResponse);
+}
+
+message SessionStatusResponse {
+  bool sessionActive = 1;
+}

--- a/RacingAidGrpc/RacingAidGrpc.csproj
+++ b/RacingAidGrpc/RacingAidGrpc.csproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0-windows</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>disable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Google.Protobuf" Version="3.31.0" />
+      <PackageReference Include="Grpc.AspNetCore.Server" Version="2.71.0" />
+      <PackageReference Include="Grpc.Net.Client" Version="2.71.0" />
+      <PackageReference Include="Grpc.Net.Common" Version="2.71.0" />
+      <PackageReference Include="Grpc.Tools" Version="2.72.0">
+        <PrivateAssets>all</PrivateAssets>
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      </PackageReference>
+    </ItemGroup>
+    
+    <ItemGroup>
+        <Protobuf Include="Protos\telemetry.proto" GrpcService="Server,Client" />
+    </ItemGroup>
+</Project>

--- a/RacingAidGrpc/TelemetryClient.cs
+++ b/RacingAidGrpc/TelemetryClient.cs
@@ -1,0 +1,69 @@
+﻿using Google.Protobuf.WellKnownTypes;
+using Grpc.Core;
+using Grpc.Net.Client;
+
+namespace RacingAidGrpc;
+
+public class TelemetryClient(GrpcChannel channel)
+{
+    private readonly Telemetry.TelemetryClient telemetryClient = new(channel);
+    
+    private CancellationTokenSource cancellationTokenSource;
+    private Task sessionStatusSubscriptionTask;
+
+    public bool IsStarted { get; private set; }
+    
+    public bool IsConnected { get; private set; }
+    
+    public event EventHandler<bool> SessionStatusUpdated;
+
+    public TelemetryClient() : this(Utils.DefaultHost, Utils.DefaultPort)
+    {
+    }
+
+    public TelemetryClient(string host, string port) : this(GrpcChannel.ForAddress($"{host}:{port}"))
+    {
+    }
+
+    public void Start()
+    {
+        if (IsStarted)
+            return;
+        
+        cancellationTokenSource = new CancellationTokenSource();
+        sessionStatusSubscriptionTask = Task.Run(() => SubscribeToSessionStatus(telemetryClient, cancellationTokenSource.Token));
+        IsStarted = true;
+    }
+
+    public void Stop()
+    {
+        if (!IsStarted)
+            return;
+        
+        cancellationTokenSource.Cancel();
+        sessionStatusSubscriptionTask.Wait();
+        IsStarted = false;
+    }
+
+    private async Task SubscribeToSessionStatus(Telemetry.TelemetryClient client, CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var call = client.SubscribeToSessionStatus(new Empty(), cancellationToken: cancellationToken);
+
+            await foreach (var response in call.ResponseStream.ReadAllAsync(cancellationToken))
+            {
+                IsConnected = response.SessionActive;
+                SessionStatusUpdated?.Invoke(this, response.SessionActive);
+            }
+        }
+        catch (RpcException ex) when (ex.StatusCode == StatusCode.Cancelled)
+        {
+            Console.WriteLine("Stream cancelled.");
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Error: {ex.Message}");
+        }
+    }
+}

--- a/RacingAidGrpc/TelemetryService.cs
+++ b/RacingAidGrpc/TelemetryService.cs
@@ -1,0 +1,44 @@
+﻿using System.Threading.Channels;
+using Google.Protobuf.WellKnownTypes;
+using Grpc.Core;
+
+namespace RacingAidGrpc;
+
+public class TelemetryService : Telemetry.TelemetryBase
+{
+    private event EventHandler<bool> StatusUpdated;
+
+    public void UpdateStatus(bool status)
+    {
+        StatusUpdated?.Invoke(this, status);
+    }
+
+    public override async Task SubscribeToSessionStatus(
+        Empty _,
+        IServerStreamWriter<SessionStatusResponse> responseStream,
+        ServerCallContext context)
+    {
+        var channel = Channel.CreateUnbounded<bool>();
+        
+        StatusUpdated += async (_, active) =>
+        {
+            await channel.Writer.WriteAsync(active);
+        };
+
+        try
+        {
+            await foreach (var active in channel.Reader.ReadAllAsync(context.CancellationToken))
+            {
+                await responseStream.WriteAsync(new SessionStatusResponse { SessionActive = active });
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Do nothing I guess
+        }
+        finally
+        {
+            channel.Writer.TryComplete(); // Close the channel when done
+        }
+    }
+}

--- a/RacingAidGrpc/Utils.cs
+++ b/RacingAidGrpc/Utils.cs
@@ -1,0 +1,7 @@
+﻿namespace RacingAidGrpc;
+
+public static class Utils
+{
+    public static string DefaultHost => "127.0.0.1";
+    public static string DefaultPort => "5000";
+}

--- a/RacingAidWpf/Core/Configuration/GeneralConfigSection.cs
+++ b/RacingAidWpf/Core/Configuration/GeneralConfigSection.cs
@@ -7,4 +7,9 @@ public class GeneralConfigSection(IConfig config) : ConfigSection(config, "Gener
         get => GetInt(nameof(UpdateIntervalMs), 33);
         set => SetValue(nameof(UpdateIntervalMs), value.ToString());
     }
+
+    /// <summary>
+    /// A get-only property for the dev mode (get only so it's hidden and only settable in the config)
+    /// </summary>
+    public bool EnabledDevMode => GetBool(nameof(EnabledDevMode), false);
 }

--- a/RacingAidWpf/Model/EnumEntryModel.cs
+++ b/RacingAidWpf/Model/EnumEntryModel.cs
@@ -1,4 +1,5 @@
-﻿using EnumsNET;
+﻿using System.Collections.ObjectModel;
+using EnumsNET;
 
 namespace RacingAidWpf.Model;
 
@@ -6,4 +7,15 @@ public class EnumEntryModel<T>(T value) where T: struct, Enum
 {
     public string Name { get; } = value.AsString(EnumFormat.Description);
     public T Value { get; } = value;
+}
+
+public static class EnumEntryModelUtility
+{
+    public static ObservableCollection<EnumEntryModel<T>> CreateObservableEnumCollection<T>() where T : struct, Enum
+    {
+        var entries = new ObservableCollection<EnumEntryModel<T>>();
+        foreach (var entry in Enum.GetValues(typeof(T)).Cast<T>())
+            entries.Add(new EnumEntryModel<T>(entry));
+        return entries;
+    }
 }

--- a/RacingAidWpf/RacingAidWpf.csproj
+++ b/RacingAidWpf/RacingAidWpf.csproj
@@ -13,7 +13,7 @@
         <PackageReference Include="Enums.NET" Version="5.0.0" />
         <PackageReference Include="IRSDKSharper" Version="1.1.3" />
         <PackageReference Include="log4net" Version="3.0.3" />
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
         <PackageReference Include="Salaros.ConfigParser" Version="0.3.8" />
     </ItemGroup>
 

--- a/RacingAidWpf/View/DevToolsView.xaml
+++ b/RacingAidWpf/View/DevToolsView.xaml
@@ -1,0 +1,57 @@
+﻿<Window x:Class="RacingAidWpf.View.DevToolsView"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:local="clr-namespace:RacingAidWpf.View"
+        xmlns:viewModel="clr-namespace:RacingAidWpf.ViewModel"
+        mc:Ignorable="d"
+        d:DataContext="{d:DesignInstance viewModel:DevToolsViewModel}"
+        Title="DevTools"
+        SizeToContent="WidthAndHeight">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <StackPanel Grid.Row="0" Orientation="Horizontal" Margin="10">
+            <Button x:Name="StartRecordingButton"
+                    Height="25" Width="100"
+                    Margin="10,0,0,0"
+                    Content="Start Recording"
+                    Command="{Binding StartRecordingCommand}"/>
+            <Button x:Name="StopRecordingButton"
+                    Height="25" Width="100"
+                    Margin="10,0,0,0"
+                    Content="Stop Recording"
+                    Command="{Binding StopRecordingCommand}"/>
+        </StackPanel>
+        <StackPanel Grid.Row="1" Orientation="Horizontal" Margin="10">
+            <Button x:Name="OpenReplaySelectorButton"
+                    Height="25" Width="100"
+                    Margin="10,0,0,0"
+                    Content="Select Replay"
+                    Command="{Binding OpenReplaySelectorCommand}"/>
+            <TextBlock x:Name="SelectedReplayTextBlock"
+                       VerticalAlignment="Center" Height="20" Width="250" Margin="10,0"
+                       Text="{Binding SelectedReplayFileName}"/>
+        </StackPanel>
+        <StackPanel Grid.Row="2" Orientation="Horizontal" Margin="10">
+            <Button x:Name="StartReplayButton"
+                    Height="25" Width="100"
+                    Margin="10,0,0,0"
+                    Content="Start Replay"
+                    Command="{Binding StartReplayCommand}"/>
+            <Button x:Name="StopReplayButton"
+                    Height="25" Width="100"
+                    Margin="10,0,0,0"
+                    Content="Stop Replay"
+                    Command="{Binding StopReplayCommand}"/>
+            <ComboBox Height="25" Width="150" Margin="10,0"
+                      ItemsSource="{Binding ReplaySpeedEntries}"
+                      SelectedValue="{Binding ReplaySpeedEntry}"
+                      DisplayMemberPath="Name"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/RacingAidWpf/View/DevToolsView.xaml.cs
+++ b/RacingAidWpf/View/DevToolsView.xaml.cs
@@ -1,0 +1,16 @@
+﻿using System.Windows;
+using RacingAidWpf.ViewModel;
+
+namespace RacingAidWpf.View;
+
+public partial class DevToolsView : Window
+{
+    private readonly DevToolsViewModel devToolViewModel = new();
+    
+    public DevToolsView()
+    {
+        InitializeComponent();
+        
+        DataContext = devToolViewModel;
+    }
+}

--- a/RacingAidWpf/View/MainWindow.xaml
+++ b/RacingAidWpf/View/MainWindow.xaml
@@ -57,36 +57,13 @@
                     </Style>
                 </ToggleButton.Style>
             </ToggleButton>
-            <Button x:Name="StartRecordingButton"
+            <Button x:Name="DevToolsButton"
                     Height="25" Width="100"
                     Margin="10,0,0,0"
-                    Content="Start Recording"
-                    Command="{Binding StartRecordingCommand}"/>
-            <Button x:Name="StopRecordingButton"
-                    Height="25" Width="100"
-                    Margin="10,0,0,0"
-                    Content="Stop Recording"
-                    Command="{Binding StopRecordingCommand}"/>
-            <Button x:Name="OpenReplaySelectorButton"
-                    Height="25" Width="100"
-                    Margin="10,0,0,0"
-                    Content="Select Replay"
-                    Command="{Binding OpenReplaySelectorCommand}"/>
-            <TextBlock x:Name="SelectedReplayTextBlock"
-                       VerticalAlignment="Center" Height="20" Width="250" Margin="10,0"
-                       Text="{Binding SelectedReplayFileName}"/>
-            <Button x:Name="StartReplayButton"
-                    Height="25" Width="100"
-                    Margin="10,0,0,0"
-                    Content="Start Replay"
-                    Command="{Binding StartReplayCommand}"/>
-            <Button x:Name="StopReplayButton"
-                    Height="25" Width="100"
-                    Margin="10,0,0,0"
-                    Content="Stop Replay"
-                    Command="{Binding StopReplayCommand}"/>
-                       
-
+                    Content="Open Dev Tools"
+                    Visibility="{Binding DevToolsVisibility}"
+                    Command="{Binding OpenDevToolsCommand}"
+                    />
         </StackPanel>
         
         <GroupBox Grid.Row="1" Grid.Column="0" Header="General" MinHeight="100" MinWidth="165">

--- a/RacingAidWpf/View/MainWindow.xaml
+++ b/RacingAidWpf/View/MainWindow.xaml
@@ -75,6 +75,16 @@
             <TextBlock x:Name="SelectedReplayTextBlock"
                        VerticalAlignment="Center" Height="20" Width="250" Margin="10,0"
                        Text="{Binding SelectedReplayFileName}"/>
+            <Button x:Name="StartReplayButton"
+                    Height="25" Width="100"
+                    Margin="10,0,0,0"
+                    Content="Start Replay"
+                    Command="{Binding StartReplayCommand}"/>
+            <Button x:Name="StopReplayButton"
+                    Height="25" Width="100"
+                    Margin="10,0,0,0"
+                    Content="Stop Replay"
+                    Command="{Binding StopReplayCommand}"/>
                        
 
         </StackPanel>

--- a/RacingAidWpf/View/MainWindow.xaml
+++ b/RacingAidWpf/View/MainWindow.xaml
@@ -21,7 +21,7 @@
             <RowDefinition Height="40"/>
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
-        <StackPanel Grid.Row="0" Grid.ColumnSpan="5" Orientation="Horizontal" HorizontalAlignment="Left" Margin="5">
+        <StackPanel Grid.Row="0" Grid.ColumnSpan="5" Orientation="Horizontal" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="5">
             <ComboBox Height="25" Width="150"
                       ItemsSource="{Binding SimulatorEntries}"
                       SelectedValue="{Binding SelectedSimulatorEntry}"
@@ -67,6 +67,15 @@
                     Margin="10,0,0,0"
                     Content="Stop Recording"
                     Command="{Binding StopRecordingCommand}"/>
+            <Button x:Name="OpenReplaySelectorButton"
+                    Height="25" Width="100"
+                    Margin="10,0,0,0"
+                    Content="Select Replay"
+                    Command="{Binding OpenReplaySelectorCommand}"/>
+            <TextBlock x:Name="SelectedReplayTextBlock"
+                       VerticalAlignment="Center" Height="20" Width="250" Margin="10,0"
+                       Text="{Binding SelectedReplayFileName}"/>
+                       
 
         </StackPanel>
         

--- a/RacingAidWpf/View/MainWindow.xaml
+++ b/RacingAidWpf/View/MainWindow.xaml
@@ -43,20 +43,30 @@
               Margin="10, 0, 0, 0"
               IsChecked="{Binding IsRepositionEnabled}" 
               IsEnabled="{Binding InSession}">
-            <ToggleButton.Style>
-                <Style TargetType="ToggleButton">
-                    <Setter Property="Content" Value="Enable Reposition" />
-                    <Style.Triggers>
-                        <DataTrigger Binding="{Binding IsRepositionEnabled}" Value="True">
-                            <Setter Property="Content" Value="Disable Reposition" />
-                        </DataTrigger>
-                        <DataTrigger Binding="{Binding IsRepositionEnabled}" Value="False">
-                            <Setter Property="Content" Value="Enable Reposition" />
-                        </DataTrigger>
-                    </Style.Triggers>
-                </Style>
-            </ToggleButton.Style>
-        </ToggleButton>
+                <ToggleButton.Style>
+                    <Style TargetType="ToggleButton">
+                        <Setter Property="Content" Value="Enable Reposition" />
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding IsRepositionEnabled}" Value="True">
+                                <Setter Property="Content" Value="Disable Reposition" />
+                            </DataTrigger>
+                            <DataTrigger Binding="{Binding IsRepositionEnabled}" Value="False">
+                                <Setter Property="Content" Value="Enable Reposition" />
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </ToggleButton.Style>
+            </ToggleButton>
+            <Button x:Name="StartRecordingButton"
+                    Height="25" Width="100"
+                    Margin="10,0,0,0"
+                    Content="Start Recording"
+                    Command="{Binding StartRecordingCommand}"/>
+            <Button x:Name="StopRecordingButton"
+                    Height="25" Width="100"
+                    Margin="10,0,0,0"
+                    Content="Stop Recording"
+                    Command="{Binding StopRecordingCommand}"/>
 
         </StackPanel>
         

--- a/RacingAidWpf/View/ReplaySelectorView.xaml
+++ b/RacingAidWpf/View/ReplaySelectorView.xaml
@@ -1,0 +1,30 @@
+﻿<Window x:Class="RacingAidWpf.View.ReplaySelectorView"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:viewModel="clr-namespace:RacingAidWpf.ViewModel"
+        mc:Ignorable="d"
+        d:DataContext="{d:DesignInstance viewModel:ReplaySelectorViewModel}"
+        Title="ReplaySelectorView"
+        Height="400"
+        Width="400">
+    <Grid>
+        <StackPanel Orientation="Vertical">
+            <ListBox Name="SelectorListBox"
+                     Margin="10"
+                     MinHeight="325"
+                     ItemsSource="{Binding ReplayFiles}"
+                     SelectedItem="{Binding SelectedReplayFile, Mode=TwoWay}"/>
+            <StackPanel Orientation="Horizontal" Height="Auto" Margin="5,0">
+                <TextBlock Name="SelectedFile"
+                           Margin="10"
+                           Height="25" Width="250"
+                           VerticalAlignment="Center"
+                           Text="{Binding SelectedReplayFile}"/>
+                <Button Name="SelectButton" Content="Select" Height="25" Width="50" Margin="5,0" Command="{Binding SelectReplayFileCommand}"/>
+                <Button Name="CloseButton" Content="Close" Height="25" Width="50" Margin="5,0" Command="{Binding CloseCommand}"/>
+            </StackPanel>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/RacingAidWpf/View/ReplaySelectorView.xaml
+++ b/RacingAidWpf/View/ReplaySelectorView.xaml
@@ -7,8 +7,9 @@
         mc:Ignorable="d"
         d:DataContext="{d:DesignInstance viewModel:ReplaySelectorViewModel}"
         Title="ReplaySelectorView"
-        Height="400"
-        Width="400">
+        SizeToContent="WidthAndHeight"
+        MinHeight="400"
+        MinWidth="400">
     <Grid>
         <StackPanel Orientation="Vertical">
             <ListBox Name="SelectorListBox"

--- a/RacingAidWpf/View/ReplaySelectorView.xaml.cs
+++ b/RacingAidWpf/View/ReplaySelectorView.xaml.cs
@@ -1,0 +1,17 @@
+﻿using System.Windows;
+using RacingAidWpf.ViewModel;
+
+namespace RacingAidWpf.View;
+
+public partial class ReplaySelectorView : Window
+{
+    private readonly ReplaySelectorViewModel replaySelectorViewModel = new();
+    
+    public ReplaySelectorView()
+    {
+        InitializeComponent();
+        
+        DataContext = replaySelectorViewModel;
+        replaySelectorViewModel.CloseRequested += Close;
+    }
+}

--- a/RacingAidWpf/ViewModel/DevToolsViewModel.cs
+++ b/RacingAidWpf/ViewModel/DevToolsViewModel.cs
@@ -1,0 +1,130 @@
+﻿using System.Collections.ObjectModel;
+using System.IO;
+using System.Windows.Input;
+using RacingAidData.Core.Replay;
+using RacingAidWpf.Commands;
+using RacingAidWpf.Core.Singleton;
+using RacingAidWpf.Model;
+using RacingAidWpf.View;
+
+namespace RacingAidWpf.ViewModel;
+
+public class DevToolsViewModel : ViewModel
+{
+    private readonly ReplayController replayController;
+
+    public event Action ReplayStarted;
+    public event Action ReplayStopped;
+    
+    public ICommand StartRecordingCommand { get; }
+    public ICommand StopRecordingCommand { get; }
+    
+    public ICommand OpenReplaySelectorCommand { get; }
+    public ICommand StartReplayCommand { get; }
+    public ICommand StopReplayCommand { get; }
+    
+    public string SelectedReplayFileName => Path.GetFileName(SelectedReplayFilePath);
+
+    private string selectedReplayFilePath;
+
+    public string SelectedReplayFilePath
+    {
+        get => selectedReplayFilePath;
+        private set
+        {
+            if (selectedReplayFilePath == value)
+                return;
+            
+            selectedReplayFilePath = value;
+            OnPropertyChanged();
+            OnPropertyChanged(nameof(SelectedReplayFileName));
+        }
+    }
+    
+    public ObservableCollection<EnumEntryModel<ReplaySpeed>> ReplaySpeedEntries { get; }
+
+    private EnumEntryModel<ReplaySpeed> replaySpeedEntry;
+    public EnumEntryModel<ReplaySpeed> ReplaySpeedEntry
+    {
+        get => replaySpeedEntry;
+        set
+        {
+            if (replaySpeedEntry == value)
+                return;
+
+            replaySpeedEntry = ReplaySpeedEntries.First(d => d == value);
+            replayController.ReplaySpeed = replaySpeedEntry.Value;
+            OnPropertyChanged();
+        }
+    }
+    
+    public DevToolsViewModel()
+    {
+        // Setup recording
+        replayController = new ReplayController();
+        
+        var racingAid = RacingAidSingleton.Instance;
+        racingAid.SetupReplayController(replayController);
+        
+        ReplaySpeedEntries = EnumEntryModelUtility.CreateObservableEnumCollection<ReplaySpeed>();
+        ReplaySpeedEntry = ReplaySpeedEntries.First();
+        
+        StartRecordingCommand = new Command(StartRecording);
+        StopRecordingCommand = new Command(StopRecording);
+
+        OpenReplaySelectorCommand = new Command(OpenReplaySelector);
+        StartReplayCommand = new Command(StartReplay);
+        StopReplayCommand = new Command(StopReplay);
+    }
+
+    private void StartRecording()
+    {
+        Logger?.LogInformation("Starting recording");
+        var recordFile = replayController.StartRecording();
+        Logger?.LogDebug($"Started recording: {recordFile}");
+    }
+
+    private void StopRecording()
+    {
+        Logger?.LogInformation("Stopping recording");
+        replayController.StopRecording();
+        Logger?.LogDebug("Stopped recording");
+    }
+
+    private void OpenReplaySelector()
+    {
+        var replaySelectorView = new ReplaySelectorView();
+        if (replaySelectorView.DataContext is ReplaySelectorViewModel viewModel)
+        {
+            viewModel.ReplayFileSelected += OnReplayFileSelected;
+            viewModel.ReplayFilePaths = [..replayController.GetReplays()];
+        }
+
+        replaySelectorView.ShowDialog();
+    }
+
+    private void OnReplayFileSelected(string replayFilePath)
+    {
+        if (!replayController.SelectReplay(replayFilePath))
+            return;
+        
+        SelectedReplayFilePath = replayFilePath;
+        Logger?.LogDebug($"Replay selected: {SelectedReplayFilePath}");
+    }
+
+    private void StartReplay()
+    {
+        Logger?.LogInformation("Starting replay");
+        replayController.StartReplay();
+        ReplayStarted?.Invoke();
+        Logger?.LogDebug("Started replay");
+    }
+
+    private void StopReplay()
+    {
+        Logger?.LogInformation("Stopping replay");
+        replayController.StopReplay();
+        ReplayStopped?.Invoke();
+        Logger?.LogDebug("Stopped replay");
+    }
+}

--- a/RacingAidWpf/ViewModel/MainWindowViewModel.cs
+++ b/RacingAidWpf/ViewModel/MainWindowViewModel.cs
@@ -37,6 +37,8 @@ public sealed class MainWindowViewModel : ViewModel
     public ICommand StopRecordingCommand { get; }
     
     public ICommand OpenReplaySelectorCommand { get; }
+    public ICommand StartReplayCommand { get; }
+    public ICommand StopReplayCommand { get; }
 
     public string SelectedReplayFileName => Path.GetFileName(SelectedReplayFilePath);
 
@@ -494,6 +496,8 @@ public sealed class MainWindowViewModel : ViewModel
         StopRecordingCommand = new Command(StopRecording);
 
         OpenReplaySelectorCommand = new Command(OpenReplaySelector);
+        StartReplayCommand = new Command(StartReplay);
+        StopReplayCommand = new Command(StopReplay);
     }
 
     public void Close()
@@ -554,10 +558,25 @@ public sealed class MainWindowViewModel : ViewModel
         replaySelectorView.ShowDialog();
     }
 
+    private void StartReplay()
+    {
+        Logger?.LogDebug("Starting replay");
+        replayController.StartReplay();
+    }
+
+    private void StopReplay()
+    {
+        Logger?.LogDebug("Stopping replay");
+        replayController.StopReplay();
+    }
+
     private void OnReplayFileSelected(string replayFilePath)
     {
         if (replayController.SelectReplay(replayFilePath))
+        {
             SelectedReplayFilePath = replayFilePath;
+            Logger?.LogDebug($"Replay selected: {SelectedReplayFilePath}");
+        }
     }
 
     private void StartRecording()

--- a/RacingAidWpf/ViewModel/MainWindowViewModel.cs
+++ b/RacingAidWpf/ViewModel/MainWindowViewModel.cs
@@ -561,12 +561,14 @@ public sealed class MainWindowViewModel : ViewModel
     private void StartReplay()
     {
         Logger?.LogDebug("Starting replay");
+        StartAndDisplayOverlays();
         replayController.StartReplay();
     }
 
     private void StopReplay()
     {
         Logger?.LogDebug("Stopping replay");
+        HideAndResetOverlays();
         replayController.StopReplay();
     }
 

--- a/RacingAidWpf/ViewModel/ReplaySelectorViewModel.cs
+++ b/RacingAidWpf/ViewModel/ReplaySelectorViewModel.cs
@@ -1,0 +1,71 @@
+﻿using System.Collections.ObjectModel;
+using System.IO;
+using System.Windows.Input;
+using RacingAidWpf.Commands;
+
+namespace RacingAidWpf.ViewModel;
+
+public class ReplaySelectorViewModel : ViewModel
+{
+    private Dictionary<string, string> replayFileMap = new();
+    
+    public event Action<string> ReplayFileSelected;
+
+    public event Action CloseRequested;
+
+    private List<string> replayFilePaths;
+
+    public List<string> ReplayFilePaths
+    {
+        get => replayFilePaths;
+        set
+        {
+            if (replayFilePaths == value)
+                return;
+            
+            replayFilePaths = value;
+            replayFileMap = replayFilePaths.ToDictionary(Path.GetFileName, f => f);
+            
+            ReplayFiles = new ObservableCollection<string>(replayFileMap.Keys);
+            OnPropertyChanged(nameof(ReplayFiles));
+        }
+    }
+    public ObservableCollection<string> ReplayFiles { get; set; }
+    
+    private string selectedReplayFile;
+    public string SelectedReplayFile
+    {
+        get => selectedReplayFile;
+        set
+        {
+            if (selectedReplayFile == value)
+                return;
+            
+            selectedReplayFile = value;
+            OnPropertyChanged();
+        }
+    }
+    
+    public ICommand SelectReplayFileCommand { get; }
+    
+    public ICommand CloseCommand { get; }
+
+    public ReplaySelectorViewModel()
+    {
+        SelectReplayFileCommand = new Command(SelectReplayFile);
+        CloseCommand = new Command(Close);
+    }
+
+    private void SelectReplayFile()
+    {
+        if (replayFileMap.TryGetValue(SelectedReplayFile, out var replayFilePath))
+            ReplayFileSelected?.Invoke(replayFilePath);
+        
+        Close();
+    }
+
+    private void Close()
+    {
+        CloseRequested?.Invoke();
+    }
+}


### PR DESCRIPTION
Added hidden dev tools view (enabled when 'EnabledDevMode' config setting is added to the `[General]` config setting).

This view gives us the ability to record all data packets and replay any recorded files.
Given this is a dev tool the buttons aren't set up in a user friendly way at the moment i.e. you can spam start/stop buttons.

The record/replay system has been created such that you can inject the `ReplayController` into the `RacingAid` class and handle it that way.

There is a replay speed control that half works too.. That should be updated at some point