### PR TITLE
Fix and improve track map calculation accuracy

### DIFF
--- a/RacingAidWpf/Core/Tracks/PositionCalculators/VelocityAndDirectionTrackMapCalculator.cs
+++ b/RacingAidWpf/Core/Tracks/PositionCalculators/VelocityAndDirectionTrackMapCalculator.cs
@@ -1,4 +1,5 @@
-﻿using RacingAidData.Core.Models;
+﻿using System.Numerics;
+using RacingAidData.Core.Models;
 
 namespace RacingAidWpf.Core.Tracks.PositionCalculators;
 
@@ -8,57 +9,35 @@ public class VelocityAndDirectionTrackMapCalculator : TrackMapPositionCalculator
     
     public override TrackMapPosition CalculatePosition(TrackMapPosition previousPosition, DriverDataModel driverDataModel, float timeDeltaMs)
     {
-        // TODO: Confirm the Z calculations are as accurate as they can be
         // NOTE: Ms for speed = metres per second, Ms time = milliseconds.. Sorry its a bit awkward
 
         if (driverDataModel.VelocityMs == null)
-            throw new ArgumentNullException($"{nameof(driverDataModel.VelocityMs)} is null");
+            throw new ArgumentNullException(
+                $"{nameof(driverDataModel)}'s {nameof(driverDataModel.VelocityMs)} is null");
         
+        var driverVelocityMs = driverDataModel.VelocityMs;
+        var driverVelocityVectorMs = new Vector3(driverVelocityMs.X, driverVelocityMs.Y, driverVelocityMs.Z);
+        
+        var yawNorth = (90f - driverDataModel.ForwardDirectionDeg) * DegToRad;
+        var pitch = -1f * driverDataModel.PitchDeg * DegToRad;
+        var roll = driverDataModel.RollDeg * DegToRad;
+
+        var rollRotation = Matrix4x4.CreateRotationX(roll);
+        var pitchRotation = Matrix4x4.CreateRotationY(pitch);
+        var yawRotation = Matrix4x4.CreateRotationZ(yawNorth);
+
+        var localToWorldRotationMatrix = rollRotation * pitchRotation * yawRotation;
+        
+        var velocityVectorMs = Vector3.Transform(driverVelocityVectorMs, localToWorldRotationMatrix);
         var timeDeltaS = timeDeltaMs / OneThousand;
         
-        var vF = driverDataModel.VelocityMs.X;
-        var vL = driverDataModel.VelocityMs.Y;
-        var vU = driverDataModel.VelocityMs.Z;
-        
-        var yawNorthDeg = driverDataModel.ForwardDirectionDeg;
-        var pitchDeg = driverDataModel.PitchDeg;
-        var rollDeg = driverDataModel.RollDeg;
-        
-        var yawNorth = yawNorthDeg * DegToRad;
-        var pitch = pitchDeg * DegToRad;
-        var roll = rollDeg * DegToRad;
-        
-        var cosYaw = MathF.Cos(yawNorth);
-        var sinYaw = MathF.Sin(yawNorth);
-        var cosPitch = MathF.Cos(pitch);
-        var sinPitch = MathF.Sin(pitch);
-        var cosRoll = MathF.Cos(roll);
-        var sinRoll = MathF.Sin(roll);
-        
-        var vFx = vF * cosPitch * sinYaw;
-        var vFy = vF * cosPitch * cosYaw;
-        var vFz = vF * sinPitch;
-
-        var vLx =  vL * (cosRoll * cosYaw - sinRoll * sinPitch * sinYaw);
-        var vLy =  vL * (cosRoll * sinYaw + sinRoll * sinPitch * cosYaw);
-        var vLz = -1f * vL * sinRoll * cosPitch;
-
-        var vUx = -1f * vU * (sinRoll * cosYaw + cosRoll * sinPitch * sinYaw);
-        var vUy = -1f * vU * (sinRoll * sinYaw - cosRoll * sinPitch * cosYaw);
-        var vUz = vU * cosRoll * cosPitch;
-
-        var vX = vFx + vLx + vUx;
-        var vY = vFy + vLy + vUy;
-        var vZ = vFz + vLz + vUz;
-        
         // Use euler-esque approximations to determine the driver's current whereabouts..
-        var approxDistanceXMetres = timeDeltaS * vX;
-        var approxDistanceYMetres = timeDeltaS * vY;
-        var approxDistanceZMetres = timeDeltaS * vZ;
+        var approxDistanceVectorMetres = velocityVectorMs * timeDeltaS;
         
-        var approximateNewX = previousPosition.X + approxDistanceXMetres;
-        var approximateNewY = previousPosition.Y + approxDistanceYMetres;
-        var approximateNewZ = previousPosition.Z + approxDistanceZMetres;
+        var approximateNewX = previousPosition.X + approxDistanceVectorMetres.X;
+        var approximateNewY = previousPosition.Y + approxDistanceVectorMetres.Y;
+        var approximateNewZ = previousPosition.Z + approxDistanceVectorMetres.Z;
+        
         return new TrackMapPosition(driverDataModel.LapDistanceMetres, approximateNewX, approximateNewY, approximateNewZ);
     }
 }


### PR DESCRIPTION
This PR will fix the inaccuracies of the track map calculations on tracks with altitude such as Rudskogen.

The worry initially was that the track map would become unusable.

The calculations now use matrices as its a bit safer (i.e. less moving parts).

The updated accuracy is as follows:
` (<axis>[-1] - <axis>[0] / max(<axis>) - min(<axis>) ) * 100`
> 0.3978813032268656%, 0.038823607181161575%, 0.19820502294046755%

Happy with this as its quite indistinguishable on the track map

![image](https://github.com/user-attachments/assets/60c5ed60-defb-4cf8-a0e8-8344577071e5)
